### PR TITLE
fix(protoc-gen-go-struct): Generate types once

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,0 +1,50 @@
+name: run-tests
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [prod-staging]
+    paths:
+      - '**'
+      - '!.github/**'
+      - .github/workflows/run-tests.yaml
+
+# Automatically cancel in-progress actions on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.work'
+          cache: false
+
+      - name: Set Go variables
+        id: goenv
+        run: |
+          {
+            echo "cache=$(go env GOCACHE)"
+            echo "modcache=$(go env GOMODCACHE)"
+            echo "mod=$(go env GOMOD)"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Go caches
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.goenv.outputs.cache }}
+            ${{ steps.goenv.outputs.modcache }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles(steps.goenv.outputs.mod) }}
+          restore-keys: |
+            ${{ github.job }}-${{ runner.os }}-go-
+
+      - name: Run tests
+        shell: bash
+        run: |
+          go list -m -f '{{.Path}}/...' | xargs go test -v

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -44,6 +44,11 @@ jobs:
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-go-
 
+      - name: Install test prerequisites
+        shell: bash
+        run: |
+          go install github.com/bufbuild/buf/cmd/buf@v1.54.0
+
       - name: Run tests
         shell: bash
         run: |

--- a/tools/protoc-gen-go-struct/main.go
+++ b/tools/protoc-gen-go-struct/main.go
@@ -214,8 +214,12 @@ func (td *TemplateData) getStructs(messages ...*protogen.Message) map[string]Str
 						f.Type = "*" + f.Type
 					}
 					// Recursively handle nested messages.
-					for k, strct := range td.getStructs(field.Message) {
-						data[k] = strct
+					if parent := field.Desc.Message().Parent(); parent != nil {
+						if _, ok := parent.(protoreflect.MessageDescriptor); ok {
+							for k, strct := range td.getStructs(field.Message) {
+								data[k] = strct
+							}
+						}
 					}
 				}
 			} else {

--- a/tools/protoc-gen-go-struct/main_test.go
+++ b/tools/protoc-gen-go-struct/main_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+func TestBufGenerate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		bufDir        string
+		generationDir string
+	}{
+		{
+			name:          "simple",
+			bufDir:        "testdata/simple/",
+			generationDir: "dist/simple",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := os.RemoveAll(tt.generationDir); err != nil {
+				t.Fatalf("unable to remove directory: %v", err)
+			}
+
+			args := []string{
+				"buf",
+				"--config",
+				filepath.Join(tt.bufDir, "buf.yaml"),
+				"generate",
+				"--template",
+				filepath.Join(tt.bufDir, "buf.gen.yaml"),
+			}
+			cmd := exec.Command(
+				args[0], args[1:]...,
+			)
+			if b, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("buf generate(%s) failed. error(%v). \nout(%s)", args, err, string(b))
+			}
+
+			typeCheck(t, tt.generationDir)
+		})
+	}
+}
+
+// typeCheck verifies that the generated code is sound golang code.
+func typeCheck(t *testing.T, dir string) {
+	t.Helper()
+
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("failed to get absolute path for %q: %v", dir, err)
+	}
+
+	cfg := &packages.Config{
+		Context: t.Context(),
+		Dir:     absDir,
+		Mode:    packages.LoadSyntax,
+	}
+
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		t.Fatalf("Failed to load package: %v", err)
+	}
+
+	for _, pkg := range pkgs {
+		if len(pkg.Errors) > 0 {
+			t.Logf("package(%s) has errors:", pkg.PkgPath)
+			for _, e := range pkg.Errors {
+				t.Log(e)
+			}
+			t.Fatalf("typeCheck failed for: %v", dir)
+		}
+	}
+}

--- a/tools/protoc-gen-go-struct/main_test.go
+++ b/tools/protoc-gen-go-struct/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"golang.org/x/tools/go/packages"
@@ -26,6 +27,11 @@ func TestBufGenerate(t *testing.T) {
 			name:          "simple",
 			bufDir:        "testdata/simple/",
 			generationDir: "dist/simple",
+		},
+		{
+			name:          "multiple-definitions",
+			bufDir:        "testdata/multiple-definitions/",
+			generationDir: "dist/multiple-definitions",
 		},
 	}
 
@@ -52,18 +58,18 @@ func TestBufGenerate(t *testing.T) {
 				t.Fatalf("buf generate(%s) failed. error(%v). \nout(%s)", args, err, string(b))
 			}
 
-			typeCheck(t, tt.generationDir)
+			typeCheck(t, tt.bufDir, tt.generationDir)
 		})
 	}
 }
 
-// typeCheck verifies that the generated code is sound golang code.
-func typeCheck(t *testing.T, dir string) {
+// typeCheck verifies that the generated code is sound golang.
+func typeCheck(t *testing.T, bufDir, generationDir string) {
 	t.Helper()
 
-	absDir, err := filepath.Abs(dir)
+	absDir, err := filepath.Abs(generationDir)
 	if err != nil {
-		t.Fatalf("failed to get absolute path for %q: %v", dir, err)
+		t.Fatalf("failed to get absolute path for %q: %v", generationDir, err)
 	}
 
 	cfg := &packages.Config{
@@ -77,13 +83,35 @@ func typeCheck(t *testing.T, dir string) {
 		t.Fatalf("Failed to load package: %v", err)
 	}
 
+	errs := []packages.Error{}
 	for _, pkg := range pkgs {
 		if len(pkg.Errors) > 0 {
-			t.Logf("package(%s) has errors:", pkg.PkgPath)
 			for _, e := range pkg.Errors {
-				t.Log(e)
+				if containsAny(t, e.Error(), []string{"no required module provides package", "could not import"}) {
+					// The generated code does not have a go.mod file; ignore package errors.
+					continue
+				}
+				errs = append(errs, e)
 			}
-			t.Fatalf("typeCheck failed for: %v", dir)
 		}
 	}
+
+	if len(errs) > 0 {
+		t.Logf("directory(%s) has errors: ", bufDir)
+		for _, e := range errs {
+			t.Log(e)
+		}
+		t.Fatalf("typeCheck failed for: %v", generationDir)
+	}
+}
+
+func containsAny(t *testing.T, s string, subs []string) bool {
+	t.Helper()
+
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
 }

--- a/tools/protoc-gen-go-struct/testdata/multiple-definitions/buf.gen.yaml
+++ b/tools/protoc-gen-go-struct/testdata/multiple-definitions/buf.gen.yaml
@@ -1,0 +1,16 @@
+version: v2
+managed:
+  enabled: false
+
+# buf --config testdata/multiple-definitions/buf.yaml generate --template testdata/multiple-definitions/buf.gen.yaml
+inputs:
+  - directory: testdata/multiple-definitions
+
+plugins:
+- local: ["go", "run", "main.go"]
+  types:
+  - "api.example.proxy.v1.AuthResponse"
+  - "api.example.proxy.v1.NodeResponse"
+  out: dist/multiple-definitions
+  opt:
+  - base_package=github.com/example/project/api

--- a/tools/protoc-gen-go-struct/testdata/multiple-definitions/buf.yaml
+++ b/tools/protoc-gen-go-struct/testdata/multiple-definitions/buf.yaml
@@ -1,0 +1,2 @@
+version: v1
+name: buf.build/local/protoc-gen-go-struct-test

--- a/tools/protoc-gen-go-struct/testdata/multiple-definitions/common/v1/common.proto
+++ b/tools/protoc-gen-go-struct/testdata/multiple-definitions/common/v1/common.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package api.example.common.v1;
+
+option go_package = "common/v1;commonv1";
+
+// The error response message for an API request.
+message ResponseError {
+  // The HTTP status code of the error.
+  uint64 status = 1 [
+    json_name = "status"
+  ];
+}

--- a/tools/protoc-gen-go-struct/testdata/multiple-definitions/proxy/v1/auth.proto
+++ b/tools/protoc-gen-go-struct/testdata/multiple-definitions/proxy/v1/auth.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package api.example.proxy.v1;
+import "common/v1/common.proto";
+option go_package = "proxy/v1;proxyv1";
+
+message AuthResponse {
+  repeated api.example.common.v1.ResponseError errors = 1;
+}

--- a/tools/protoc-gen-go-struct/testdata/multiple-definitions/proxy/v1/node.proto
+++ b/tools/protoc-gen-go-struct/testdata/multiple-definitions/proxy/v1/node.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package api.example.proxy.v1;
+import "common/v1/common.proto";
+option go_package = "proxy/v1;proxyv1";
+
+// The response message for certificate activation.
+message NodeResponse {
+  repeated api.example.common.v1.ResponseError errors = 1;
+}

--- a/tools/protoc-gen-go-struct/testdata/simple/auth.proto
+++ b/tools/protoc-gen-go-struct/testdata/simple/auth.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package protoc.gen.go.struct.api;
+
+option go_package = "example.com/protocgen/struct/api;api";
+
+message AuthResponse {
+  string hostname = 1;
+}

--- a/tools/protoc-gen-go-struct/testdata/simple/buf.gen.yaml
+++ b/tools/protoc-gen-go-struct/testdata/simple/buf.gen.yaml
@@ -1,0 +1,15 @@
+version: v2
+managed:
+  enabled: false
+
+# buf --config testdata/simple/buf.yaml generate --template testdata/simple/buf.gen.yaml
+inputs:
+  - directory: testdata/simple
+
+plugins:
+- local: ["go", "run", "main.go"]
+  types:
+  - "protoc.gen.go.struct.api.AuthResponse"
+  out: dist/simple
+  opt:
+  - base_package=github.com/example/project/api

--- a/tools/protoc-gen-go-struct/testdata/simple/buf.yaml
+++ b/tools/protoc-gen-go-struct/testdata/simple/buf.yaml
@@ -1,0 +1,2 @@
+version: v1
+name: buf.build/local/protoc-gen-go-struct-test


### PR DESCRIPTION
There's a bug where protoc-gen-go-struct would generate the same type definition multiple times(once for each time it is referenced). This PR fixes that. 
We also add tests that reproduce the issue and assert that it is fixed