### PR TITLE
fix(kingkong): Avoid double dot in kingkong help

### DIFF
--- a/kingkong/help.go
+++ b/kingkong/help.go
@@ -429,16 +429,13 @@ func helpValueFormatter(value *kong.Value) string {
 	var buf strings.Builder
 
 	// Remove trailing period from help text.
-	buf.WriteString(DimmedColor(strings.TrimSuffix(value.Help, ".") + "."))
+	buf.WriteString(DimmedColor(strings.TrimSuffix(value.Help, ".")))
 
 	if len(value.Tag.Envs) > 0 {
 		buf.WriteString(" (" + formatEnvs(value.Tag.Envs) + ")")
 	}
 
-	if len(value.Default) == 0 && len(value.Tag.Enum) == 0 {
-		buf.WriteString(DimmedColor("."))
-	}
-
+	buf.WriteString(DimmedColor("."))
 	buf.WriteString("\n")
 
 	if len(value.Default) > 0 {


### PR DESCRIPTION
Something like the following was possible:

    -v, --version
        Print version information..

Note the double dot after the description, which is confusing. The end of the first line should always have a single dot.