### PR TITLE
feat(protoc-gen-go-gin): Add stream "keepalive" & "data prefix" options

### DIFF
--- a/tools/protoc-gen-go-gin/gin.tmpl
+++ b/tools/protoc-gen-go-gin/gin.tmpl
@@ -122,7 +122,7 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 
 	{{ if $.StreamKeepalive -}}
 	// Send an initial keep-alive comment to establish the connection.
-	if _, err := fmt.Fprintf(g.Writer, ": keepalive %s\n\n", time.Now().Format(time.RFC3339)); err != nil {
+	if _, err := fmt.Fprintf(g.Writer, ": keepalive %s\n", time.Now().Format(time.RFC3339)); err != nil {
 		log.G(g.Request.Context()).
 			Warn().
 			Err(err).
@@ -176,7 +176,7 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 	{{ if $.StreamKeepalive -}}
 		case <-ticker.C:
 			// Send a comment as a keepalive
-			if _, err := fmt.Fprintf(g.Writer, ": keepalive %s\n\n", time.Now().Format(time.RFC3339)); err != nil {
+			if _, err := fmt.Fprintf(g.Writer, ": keepalive %s\n", time.Now().Format(time.RFC3339)); err != nil {
 				log.G(g.Request.Context()).
 					Warn().
 					Err(err).
@@ -203,7 +203,7 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 			}
 
 			// Send the event
-			if _, err := fmt.Fprintf(g.Writer, "{{ if ne $.StreamDataPrefix "" }}{{ $.StreamDataPrefix }}: {{end}}%s\n\n", jsonData); err != nil {
+			if _, err := fmt.Fprintf(g.Writer, "{{ if ne $.StreamDataPrefix "" }}{{ $.StreamDataPrefix }}: {{end}}%s\n", jsonData); err != nil {
 				log.G(g.Request.Context()).
 					Warn().
 					Err(err).

--- a/tools/protoc-gen-go-gin/gin.tmpl
+++ b/tools/protoc-gen-go-gin/gin.tmpl
@@ -203,7 +203,7 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 			}
 
 			// Send the event
-			if _, err := fmt.Fprintf(g.Writer, "data: %s\n\n", jsonData); err != nil {
+			if _, err := fmt.Fprintf(g.Writer, "{{ if ne $.StreamDataPrefix "" }}{{ $.StreamDataPrefix }}: {{end}}%s\n\n", jsonData); err != nil {
 				log.G(g.Request.Context()).
 					Warn().
 					Err(err).

--- a/tools/protoc-gen-go-gin/gin.tmpl
+++ b/tools/protoc-gen-go-gin/gin.tmpl
@@ -120,6 +120,7 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 	g.Header("Connection", "keep-alive")
 	g.Header("X-Accel-Buffering", "no") // UKC's proxy is based on NGINX.
 
+	{{ if $.StreamKeepalive -}}
 	// Send an initial keep-alive comment to establish the connection.
 	if _, err := fmt.Fprintf(g.Writer, ": keepalive %s\n\n", time.Now().Format(time.RFC3339)); err != nil {
 		log.G(g.Request.Context()).
@@ -127,6 +128,7 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 			Err(err).
 			Msg("failed to send keepalive")
 	}
+	{{- end }}
 
 	// Flush headers immediately
 	g.Writer.Flush()
@@ -150,9 +152,11 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 	{{- end -}}
 	)
 
+	{{ if $.StreamKeepalive -}}
 	// Set up a heartbeat to keep the connection alive
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
+	{{- end }}
 
 	// Create a notification channel for client disconnection
 	clientGone := g.Request.Context().Done()
@@ -169,6 +173,7 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 			// Context was cancelled or deadline exceeded
 			return
 
+	{{ if $.StreamKeepalive -}}
 		case <-ticker.C:
 			// Send a comment as a keepalive
 			if _, err := fmt.Fprintf(g.Writer, ": keepalive %s\n\n", time.Now().Format(time.RFC3339)); err != nil {
@@ -179,6 +184,7 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 				return
 			}
 			g.Writer.Flush()
+	{{ end }}
 
 		case data, ok := <-dataCh:
 			if !ok {

--- a/tools/protoc-gen-go-gin/main.go
+++ b/tools/protoc-gen-go-gin/main.go
@@ -22,10 +22,11 @@ import (
 const pluginName = "unikraft.com/x/tools/protoc-gen-go-gin"
 
 type TemplateData struct {
-	PluginName      string
-	Package         string
-	Services        []Service
-	StreamKeepalive bool
+	PluginName       string
+	Package          string
+	Services         []Service
+	StreamKeepalive  bool
+	StreamDataPrefix string
 }
 
 type Service struct {
@@ -51,6 +52,7 @@ var ginTmpl string
 func main() {
 	var flags flag.FlagSet
 	streamKeepalive := flags.Bool("stream_keepalive", true, "Send a regular keep-alive with a timestamp in streaming responses")
+	streamDataPrefix := flags.String("stream_data_prefix", "data", "Set a prefix for data messages in streaming responses")
 
 	protogen.Options{
 		ParamFunc: flags.Set,
@@ -59,7 +61,7 @@ func main() {
 			if !file.Generate {
 				continue
 			}
-			if err := generateFile(plugin, file, *streamKeepalive); err != nil {
+			if err := generateFile(plugin, file, *streamKeepalive, *streamDataPrefix); err != nil {
 				return err
 			}
 		}
@@ -68,7 +70,7 @@ func main() {
 	})
 }
 
-func generateFile(plugin *protogen.Plugin, file *protogen.File, streamKeepalive bool) error {
+func generateFile(plugin *protogen.Plugin, file *protogen.File, streamKeepalive bool, streamDataPrefix string) error {
 	services := getHTTPServices(file.Services)
 
 	// No service has http option.
@@ -77,10 +79,11 @@ func generateFile(plugin *protogen.Plugin, file *protogen.File, streamKeepalive 
 	}
 
 	templateData := TemplateData{
-		PluginName:      pluginName,
-		Package:         string(file.GoPackageName),
-		Services:        services,
-		StreamKeepalive: streamKeepalive,
+		PluginName:       pluginName,
+		Package:          string(file.GoPackageName),
+		Services:         services,
+		StreamKeepalive:  streamKeepalive,
+		StreamDataPrefix: streamDataPrefix,
 	}
 
 	tmpl, err := template.

--- a/tools/protoc-gen-go-gin/main.go
+++ b/tools/protoc-gen-go-gin/main.go
@@ -22,9 +22,10 @@ import (
 const pluginName = "unikraft.com/x/tools/protoc-gen-go-gin"
 
 type TemplateData struct {
-	PluginName string
-	Package    string
-	Services   []Service
+	PluginName      string
+	Package         string
+	Services        []Service
+	StreamKeepalive bool
 }
 
 type Service struct {
@@ -49,6 +50,7 @@ var ginTmpl string
 
 func main() {
 	var flags flag.FlagSet
+	streamKeepalive := flags.Bool("stream_keepalive", true, "Send a regular keep-alive with a timestamp in streaming responses")
 
 	protogen.Options{
 		ParamFunc: flags.Set,
@@ -57,7 +59,7 @@ func main() {
 			if !file.Generate {
 				continue
 			}
-			if err := generateFile(plugin, file); err != nil {
+			if err := generateFile(plugin, file, *streamKeepalive); err != nil {
 				return err
 			}
 		}
@@ -66,7 +68,7 @@ func main() {
 	})
 }
 
-func generateFile(plugin *protogen.Plugin, file *protogen.File) error {
+func generateFile(plugin *protogen.Plugin, file *protogen.File, streamKeepalive bool) error {
 	services := getHTTPServices(file.Services)
 
 	// No service has http option.
@@ -75,9 +77,10 @@ func generateFile(plugin *protogen.Plugin, file *protogen.File) error {
 	}
 
 	templateData := TemplateData{
-		PluginName: pluginName,
-		Package:    string(file.GoPackageName),
-		Services:   services,
+		PluginName:      pluginName,
+		Package:         string(file.GoPackageName),
+		Services:        services,
+		StreamKeepalive: streamKeepalive,
 	}
 
 	tmpl, err := template.


### PR DESCRIPTION
This PR adds two new options to the `protoc-gen-go-gin` generator:
1. `stream_keepalive` which is a boolean option which toggles whether to send regular keep-alives on the stream (still prefixed with `:`); and,
2. `stream_data_prefix` which is a string and sets the prefix to all messages in a stream. By default this is set to `data` which will result in something along the lines of:
   ```
   data: {}
   ```
   When left unset to an empty string value, this is entirely removed.

A minor additional refactor is included removes additional new lines.