### PR TITLE
fix(protoc-gen-go-gin): Flush headers after invoking interface method

### DIFF
--- a/tools/protoc-gen-go-gin/gin.tmpl
+++ b/tools/protoc-gen-go-gin/gin.tmpl
@@ -130,9 +130,6 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 	}
 	{{- end }}
 
-	// Flush headers immediately
-	g.Writer.Flush()
-
 	// Create a cancellable context
 	streamCtx, cancel := context.WithCancel(g.Request.Context())
 	defer cancel()
@@ -151,6 +148,9 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 	&in
 	{{- end -}}
 	)
+
+	// Flush headers after calling the service.
+	g.Writer.Flush()
 
 	{{ if $.StreamKeepalive -}}
 	// Set up a heartbeat to keep the connection alive


### PR DESCRIPTION
This makes it possible for the implementing interface method to also manipulate the headers before it returns; either overriding existing headers (like `Content-Type`) or adding additional headers such that the client is properly feeded with such information.

