### PR TITLE
feat(protoc-gen-go-gin): Save request body and restore service

### DIFF
--- a/tools/protoc-gen-go-gin/gin.tmpl
+++ b/tools/protoc-gen-go-gin/gin.tmpl
@@ -3,9 +3,11 @@
 package {{.Package}}
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -16,9 +18,11 @@ import (
 
 // Prevent import errors.
 var (
+	_ bytes.Buffer
 	_ context.Context
 	_ fmt.Stringer
 	_ http.RoundTripper
+	_ io.Reader
 	_ json.Marshaler
 	_ log.Level
 	_ time.Time
@@ -98,6 +102,23 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 
 	{{ end -}}
 	{{- if ne $method.Input.Desc.FullName "google.protobuf.Empty" -}}
+	bodyBytes, err := g.GetRawData()
+	if err != nil {
+		log.G(g.Request.Context()).
+			Warn().
+			Err(err).
+			Msg("failed to read request body")
+		if handler.resp != nil {
+			handler.resp(g, http.StatusBadRequest, err)
+		} else {
+			g.JSON(http.StatusBadRequest, err)
+		}
+		return
+	}
+
+	// Restore the body for further use.
+	g.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
 	var in {{ $method.Input.GoIdent.GoName }}
 	if err := g.ShouldBind(&in); err != nil {
 		log.G(g.Request.Context()).
@@ -111,6 +132,9 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 		}
 		return
 	}
+
+	// Restore the body for further use.
+	g.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
 	{{ end -}}
 	{{- if $method.IsStreamingServer }}


### PR DESCRIPTION
This PR makes it possible for an implementing service to read the request body.  Without this change, the subsequent `g.ShouldBind` method will read the request body and serialize it into the input message type; leaving the `g.Request.Body` ready empty.  Since `Body` does not implement `io.Seeker`, it is not possible to reset the offset.  Instead, we save the bytes into a temporary buffer and simply restore it to the `Body` before invoking the implementing method.  This makes it possible for the implementing interface method to read the body also.

