### PR TITLE
ci(commitlint): Do not validate PR title for Dependabot

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Validate PR
         id: validate-pr
-        if: ${{ steps.validate-commits.outcome == 'success' || steps.validate-commits.outcome == 'failure' }}
+        if: ${{ (steps.validate-commits.outcome == 'success' || steps.validate-commits.outcome == 'failure') && github.actor != 'dependabot' && github.actor != 'dependabot[bot]' }}
         run: |
           echo "$TITLE" | PR=yes npx commitlint --verbose
         env:


### PR DESCRIPTION
Dependabot will create PR titles which are greater than 75
characters in length, just ignore this as it's not something we
can control.

Signed-off-by: Alexander Jung <alex@unikraft.com>
