### PR TITLE
feat(log): Use stderr for logging

### DIFF
--- a/log/context.go
+++ b/log/context.go
@@ -34,7 +34,7 @@ func FromContextOrDefault(ctx context.Context) *Logger {
 		return v
 	}
 
-	return New(os.Stdout, "text", InfoLevel)
+	return New(os.Stderr, "text", InfoLevel)
 }
 
 // WithLogger returns a new Context, derived from ctx, which carries the


### PR DESCRIPTION
Logs belong on stderr.

<img width="498" height="375" alt="image" src="https://media1.tenor.com/m/aQZKtHDOt2UAAAAC/where-is.gif" />

In the CLI, we want the actual output to be in stdout and logs and such in stderr - then we can nicely do shell redirects that work as expected.