### PR TITLE
feat(oidext): Add oidext module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,13 @@ updates:
     time: '09:00'
 
 - package-ecosystem: gomod
+  directory: /oidext
+  schedule:
+    interval: weekly
+    day: sunday
+    time: '09:00'
+
+- package-ecosystem: gomod
   directory: /router
   schedule:
     interval: weekly

--- a/go.work
+++ b/go.work
@@ -10,6 +10,7 @@ use (
 	./limiter
 	./log
 	./middleware
+	./oidext
 	./ptr
 	./ringbuffer
 	./router

--- a/oidext/README.md
+++ b/oidext/README.md
@@ -1,0 +1,73 @@
+# `oidext`
+
+`oidext` is a small Go module for **mapping Go structs to ASN.1 OID-based X.509 extensions**, and back again.
+
+It is designed for use with **X.509 certificates and certificate signing requests (CSRs)** where additional, structured metadata must be embedded as **custom extensions**, such as:
+
+- Host or workload attributes
+- Platform or attestation metadata
+- Licensing or entitlement claims
+- Infrastructure fingerprints
+
+Each exported struct field is encoded as a **distinct ASN.1 DER value**, stored under its own OID, derived from a **caller-supplied prefix OID** and a **field-specific suffix**.
+
+
+## Design goals
+
+- **Deterministic and explicit**
+  Every field maps to a clearly defined OID; no implicit or heuristic behavior.
+
+- **CSR- and certificate-friendly**
+  Produces `pkix.Extension` values that can be directly attached to:
+  - `x509.CertificateRequest.Extensions`
+  - `x509.Certificate.ExtraExtensions`
+
+- **Strong typing**
+  Uses Go’s `encoding/asn1` directly - with additional support for floating points.
+
+- **Prefix-based OID namespacing**
+  All extensions are derived from a single prefix OID (e.g. an enterprise or product OID).
+
+- **Round-trip safe**
+  Encode → decode produces the original struct values.
+
+- **Minimal dependencies**
+  Standard library only.
+
+
+## Conceptual model
+
+Given:
+
+- A **prefix OID** (e.g. `1.3.6.1.4.1.55555.1`)
+- A Go struct with tagged fields
+
+```go
+type HostAttributes struct {
+  Hostname    string `oid:"1,critical"`
+  Fingerprint []byte `oid:"2,omitempty"`
+  Cpus        int    `oid:"3"`
+}
+
+const prefix = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 55555, 1}
+
+attrs := HostAttributes{
+  Hostname:    "node0-1",
+  Fingerprint: []byte{0xde, 0xad, 0xb0, 0xb0}
+}
+
+// To encode:
+exts, err := oidext.Encode(prefix, attrs)
+if err != nil {
+  log.Fatal(err)
+}
+
+// Attach to a CSR or certificate:
+csr.ExtraExtensions = append(csr.ExtraExtensions, exts...)
+
+// Later, decoding:
+exts, err = oidext.Decode(prefix, csr.Extensions, &attrs)
+if err != nil {
+  log.Fatal(err)
+}
+```

--- a/oidext/go.mod
+++ b/oidext/go.mod
@@ -1,0 +1,3 @@
+module unikraft.com/x/oidext
+
+go 1.25.5

--- a/oidext/oidext.go
+++ b/oidext/oidext.go
@@ -1,0 +1,420 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+// Package oidext provides a structured, deterministic mapping between Go
+// structs and ASN.1 OID-based X.509 extensions.
+//
+// It is intended for use with X.509 certificates and certificate signing
+// requests (CSRs) where additional, application-specific metadata must be
+// encoded as standards-compliant extensions.
+//
+// Each exported struct field is mapped to a unique Object Identifier (OID),
+// constructed by appending a field-specific suffix (declared via struct tags)
+// to a caller-supplied prefix OID. Field values are ASN.1 DER-encoded using
+// Go’s encoding/asn1 package and emitted as pkix.Extension values.
+//
+// The package supports round-trip encoding and decoding, critical extensions,
+// optional fields, nested structs, and deterministic extension ordering. It
+// deliberately avoids implicit behavior and schema inference, favoring explicit
+// OID assignment and strong typing.
+//
+// Typical use cases include private PKI extensions, CSR metadata injection,
+// workload or host identity attributes, licensing claims, and platform-specific
+// certificate annotations.
+package oidext
+
+import (
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+var (
+	ErrNotStructPointer = errors.New("value must be a non-nil pointer to a struct")
+	ErrNotStruct        = errors.New("value must be a struct or pointer to struct")
+)
+
+// Encode encodes exported struct fields into pkix.Extensions. Each exported
+// field must have an `oid:"<suffix>"` tag unless WithEncodeIgnoreUntagged() is
+// passed as an option.
+//
+// The full OID is prefixOID + suffixOID (concatenation of arcs).
+//
+// Tags:
+//   - oid:"1.2.3" (suffix arcs)
+//   - critical
+//   - omitempty   (skip if zero value; pointers nil considered zero)
+//
+// Convenience combined tag form is also supported in `oid`:
+//
+//   - oid:"1.2.3,critical,omitempty"
+func Encode(prefixOID asn1.ObjectIdentifier, v any, opts ...EncodeOption) ([]pkix.Extension, error) {
+	cfg := defaultEncodeConfig()
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	rv := reflect.ValueOf(v)
+	if !rv.IsValid() {
+		return nil, ErrNotStruct
+	}
+	if rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return nil, ErrNotStruct
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return nil, ErrNotStruct
+	}
+
+	rt := rv.Type()
+	var exts []pkix.Extension
+
+	for i := 0; i < rt.NumField(); i++ {
+		sf := rt.Field(i)
+		if sf.PkgPath != "" {
+			continue
+		}
+
+		tag := parseFieldTag(sf)
+		if tag.skip {
+			continue
+		}
+
+		if len(tag.suffixOID) == 0 {
+			if cfg.ignoreUntagged {
+				continue
+			}
+			return nil, fmt.Errorf("field %s: missing oid tag", sf.Name)
+		}
+
+		fv := rv.Field(i)
+		if tag.omitempty && isZeroValue(fv) {
+			continue
+		}
+
+		der, err := marshalFieldValue(fv)
+		if err != nil {
+			return nil, fmt.Errorf("field %s: %w", sf.Name, err)
+		}
+
+		exts = append(exts, pkix.Extension{
+			Id:       slices.Concat(prefixOID, tag.suffixOID),
+			Critical: tag.critical,
+			Value:    der,
+		})
+	}
+
+	sort.Slice(exts, func(i, j int) bool {
+		return compareOID(exts[i].Id, exts[j].Id) < 0
+	})
+
+	return exts, nil
+}
+
+// Decode populates out (pointer to struct) from pkix.Extensions. It matches
+// extensions by full OID = prefixOID + suffixOID for each tagged field.
+//
+// Behavior:
+//   - Unknown extensions are ignored (by default).
+//   - Missing fields: if WithDecodeRequireAll() is used, missing required
+//     fields error.  A field is considered "required" if it is not omitempty
+//     and not a pointer.
+func Decode(prefixOID asn1.ObjectIdentifier, exts []pkix.Extension, out any, opts ...DecodeOption) error {
+	cfg := defaultDecodeConfig()
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	rv := reflect.ValueOf(out)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return ErrNotStructPointer
+	}
+	rv = rv.Elem()
+	if rv.Kind() != reflect.Struct {
+		return ErrNotStructPointer
+	}
+
+	extMap := make(map[string]pkix.Extension, len(exts))
+	for _, e := range exts {
+		extMap[e.Id.String()] = e
+	}
+
+	rt := rv.Type()
+
+	for i := range rt.NumField() {
+		sf := rt.Field(i)
+		if sf.PkgPath != "" {
+			continue
+		}
+
+		tag := parseFieldTag(sf)
+		if tag.skip || len(tag.suffixOID) == 0 {
+			continue
+		}
+
+		fullOID := slices.Concat(prefixOID, tag.suffixOID)
+		ext, ok := extMap[fullOID.String()]
+		if !ok {
+			if cfg.requireAll && !tag.omitempty && sf.Type.Kind() != reflect.Pointer {
+				return fmt.Errorf(
+					"missing required extension for field %s (oid %s)",
+					sf.Name,
+					fullOID.String(),
+				)
+			}
+			continue
+		}
+
+		if err := unmarshalIntoField(ext.Value, rv.Field(i)); err != nil {
+			return fmt.Errorf("field %s: %w", sf.Name, err)
+		}
+	}
+
+	return nil
+}
+
+type fieldTag struct {
+	suffixOID asn1.ObjectIdentifier
+	critical  bool
+	omitempty bool
+	skip      bool
+}
+
+func parseFieldTag(sf reflect.StructField) fieldTag {
+	var ft fieldTag
+
+	raw := strings.TrimSpace(sf.Tag.Get("oid"))
+	if raw == "-" {
+		ft.skip = true
+		return ft
+	}
+
+	var (
+		seenCritical  bool
+		seenOmitEmpty bool
+	)
+
+	if raw != "" {
+		parts := splitCSVLike(raw)
+		if len(parts) > 0 {
+			oidPart := strings.TrimSpace(parts[0])
+			if oidPart != "" {
+				soid, err := parseOID(oidPart)
+				if err == nil {
+					ft.suffixOID = soid
+				}
+			}
+		}
+
+		for _, p := range parts[1:] {
+			switch strings.ToLower(strings.TrimSpace(p)) {
+			case "critical":
+				ft.critical = true
+				seenCritical = true
+			case "omitempty":
+				ft.omitempty = true
+				seenOmitEmpty = true
+			}
+		}
+	}
+
+	// Legacy fallback tags (only if not explicitly set in oid tag)
+	if !seenCritical && isTruthy(sf.Tag.Get("critical")) {
+		ft.critical = true
+	}
+	if !seenOmitEmpty && isTruthy(sf.Tag.Get("omitempty")) {
+		ft.omitempty = true
+	}
+
+	return ft
+}
+
+func splitCSVLike(s string) []string {
+	// Simple split: no quoted commas supported (good enough for our tags).
+	raw := strings.Split(s, ",")
+	out := make([]string, 0, len(raw))
+	for _, r := range raw {
+		out = append(out, strings.TrimSpace(r))
+	}
+	return out
+}
+
+func isTruthy(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "1", "true", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseOID(dotted string) (asn1.ObjectIdentifier, error) {
+	dotted = strings.TrimSpace(dotted)
+	if dotted == "" {
+		return nil, errors.New("empty oid")
+	}
+	arcs := strings.Split(dotted, ".")
+	oid := make(asn1.ObjectIdentifier, 0, len(arcs))
+	for _, a := range arcs {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			return nil, fmt.Errorf("invalid oid: %q", dotted)
+		}
+
+		n, err := strconv.Atoi(a)
+		if err != nil {
+			return nil, fmt.Errorf("invalid oid arc %q in %q", a, dotted)
+		}
+
+		oid = append(oid, n)
+	}
+	return oid, nil
+}
+
+func compareOID(a, b asn1.ObjectIdentifier) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] < b[i] {
+			return -1
+		}
+		if a[i] > b[i] {
+			return 1
+		}
+	}
+	switch {
+	case len(a) < len(b):
+		return -1
+	case len(a) > len(b):
+		return 1
+	default:
+		return 0
+	}
+}
+
+func marshalFieldValue(v reflect.Value) ([]byte, error) {
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return nil, errors.New("nil pointer")
+		}
+		v = v.Elem()
+	}
+
+	if v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return nil, errors.New("nil interface")
+		}
+		v = v.Elem()
+	}
+
+	// OID attributes do not support float-types.  As a workaround, we handle
+	// them specially by encoding their bit-pattern as a byte-slice.
+	switch v.Kind() {
+	case reflect.Float32:
+		bits := math.Float32bits(float32(v.Float()))
+		buf := make([]byte, 4)
+		binary.BigEndian.PutUint32(buf, bits)
+		return asn1.Marshal(buf)
+
+	case reflect.Float64:
+		bits := math.Float64bits(v.Float())
+		buf := make([]byte, 8)
+		binary.BigEndian.PutUint64(buf, bits)
+		return asn1.Marshal(buf)
+
+	default:
+		return asn1.Marshal(v.Interface())
+	}
+}
+
+func unmarshalIntoField(der []byte, field reflect.Value) error {
+	if !field.CanSet() {
+		return errors.New("field cannot be set")
+	}
+
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+		return unmarshalIntoField(der, field.Elem())
+	}
+
+	switch field.Kind() {
+	case reflect.Float32:
+		var buf []byte
+		rest, err := asn1.Unmarshal(der, &buf)
+		if err != nil {
+			return err
+		}
+		if len(rest) != 0 {
+			return errors.New("trailing data")
+		}
+		if len(buf) != 4 {
+			return fmt.Errorf("invalid float32 length: %d", len(buf))
+		}
+		bits := binary.BigEndian.Uint32(buf)
+		field.SetFloat(float64(math.Float32frombits(bits)))
+		return nil
+
+	case reflect.Float64:
+		var buf []byte
+		rest, err := asn1.Unmarshal(der, &buf)
+		if err != nil {
+			return err
+		}
+		if len(rest) != 0 {
+			return errors.New("trailing data")
+		}
+		if len(buf) != 8 {
+			return fmt.Errorf("invalid float64 length: %d", len(buf))
+		}
+		bits := binary.BigEndian.Uint64(buf)
+		field.SetFloat(math.Float64frombits(bits))
+		return nil
+	}
+
+	tmpPtr := reflect.New(field.Type())
+	rest, err := asn1.Unmarshal(der, tmpPtr.Interface())
+	if err != nil {
+		return err
+	}
+	if len(rest) != 0 {
+		return errors.New("trailing data")
+	}
+
+	field.Set(tmpPtr.Elem())
+	return nil
+}
+
+func isZeroValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Interface, reflect.Slice, reflect.Map, reflect.Func:
+		return v.IsNil()
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if !isZeroValue(v.Index(i)) {
+				return false
+			}
+		}
+		return true
+	case reflect.Struct:
+		// reflect.Value.IsZero exists in modern Go
+		return v.IsZero()
+	default:
+		return v.IsZero()
+	}
+}

--- a/oidext/oidext_options.go
+++ b/oidext/oidext_options.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package oidext
+
+// EncodeOptions controls encoding behavior.
+type EncodeOption func(*encodeConfig)
+
+type encodeConfig struct {
+	// If true, fields without an `oid` tag are ignored instead of erroring.
+	ignoreUntagged bool
+}
+
+func defaultDecodeConfig() *decodeConfig {
+	return &decodeConfig{
+		ignoreUnknown: true,
+		requireAll:    false,
+	}
+}
+
+// WithEncodeIgnoreUntagged causes exported struct fields without an `oid` tag
+// to be ignored instead of producing an error.
+func WithEncodeIgnoreUntagged() EncodeOption {
+	return func(c *encodeConfig) {
+		c.ignoreUntagged = true
+	}
+}
+
+// DecodeOption controls decoding behavior.
+type DecodeOption func(*decodeConfig)
+
+type decodeConfig struct {
+	// If true, unknown extensions under the prefix are ignored (default true).
+	ignoreUnknown bool
+	// If true, missing non-omitempty, non-pointer fields produce an error.
+	requireAll bool
+}
+
+func defaultEncodeConfig() *encodeConfig {
+	return &encodeConfig{
+		ignoreUntagged: false,
+	}
+}
+
+// WithDecodeIgnoreUnknown causes unknown extensions under the prefix
+// to be ignored. This is the default.
+func WithDecodeIgnoreUnknown() DecodeOption {
+	return func(c *decodeConfig) {
+		c.ignoreUnknown = true
+	}
+}
+
+// WithDecodeRequireAll causes decoding to fail if any non-omitempty,
+// non-pointer field is missing.
+func WithDecodeRequireAll() DecodeOption {
+	return func(c *decodeConfig) {
+		c.requireAll = true
+	}
+}

--- a/oidext/oidext_test.go
+++ b/oidext/oidext_test.go
@@ -1,0 +1,199 @@
+package oidext
+
+import (
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type Inner struct {
+	Role string `oid:"10"`
+}
+
+type HostAttrs struct {
+	Hostname    string    `oid:"1,critical"`
+	Fingerprint []byte    `oid:"2"`
+	BootCount   int       `oid:"3"`
+	Enabled     bool      `oid:"4"`
+	Tags        []string  `oid:"5"`
+	When        time.Time `oid:"6"`
+	Inner       Inner     `oid:"7"`
+	Optional    *string   `oid:"8,omitempty"`
+	SkipMe      string    `oid:"-"` // explicit skip
+}
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	prefix := asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 16, 0} // arbitrary example
+
+	opt := "hello"
+	in := HostAttrs{
+		Hostname:    "node-01",
+		Fingerprint: []byte{0xde, 0xad, 0xbe, 0xef},
+		BootCount:   42,
+		Enabled:     true,
+		Tags:        []string{"a", "b", "c"},
+		When:        time.Date(2026, 1, 4, 12, 0, 0, 0, time.UTC),
+		Inner:       Inner{Role: "worker"},
+		Optional:    &opt,
+		SkipMe:      "should not appear",
+	}
+
+	exts, err := Encode(prefix, in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	// Ensure Hostname extension is present and critical
+	wantHostnameOID := append(prefix, 1)
+	found := false
+	for _, e := range exts {
+		if e.Id.String() == wantHostnameOID.String() {
+			found = true
+			if !e.Critical {
+				t.Fatalf("expected hostname extension to be critical")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("did not find hostname extension")
+	}
+
+	var out HostAttrs
+	if err := Decode(prefix, exts, &out, WithDecodeIgnoreUnknown()); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+
+	// SkipMe is untagged via "-", should remain zero
+	if out.SkipMe != "" {
+		t.Fatalf("expected SkipMe to be empty, got %q", out.SkipMe)
+	}
+
+	// Compare values (time.Time and pointer included)
+	if !reflect.DeepEqual(in.Hostname, out.Hostname) ||
+		!reflect.DeepEqual(in.Fingerprint, out.Fingerprint) ||
+		in.BootCount != out.BootCount ||
+		in.Enabled != out.Enabled ||
+		!reflect.DeepEqual(in.Tags, out.Tags) ||
+		!in.When.Equal(out.When) ||
+		!reflect.DeepEqual(in.Inner, out.Inner) ||
+		(out.Optional == nil || *out.Optional != *in.Optional) {
+		t.Fatalf("roundtrip mismatch:\n in=%#v\nout=%#v", in, out)
+	}
+}
+
+func TestOmitemptyPointer(t *testing.T) {
+	prefix := asn1.ObjectIdentifier{1, 2, 3}
+
+	in := HostAttrs{
+		Hostname:    "x",
+		Fingerprint: []byte{1, 2, 3},
+		BootCount:   1,
+		Enabled:     false,
+		Tags:        nil,
+		When:        time.Date(2026, 1, 4, 0, 0, 0, 0, time.UTC),
+		Inner:       Inner{Role: "r"},
+		Optional:    nil, // omitempty
+	}
+
+	exts, err := Encode(prefix, in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	// Optional (suffix 8) should not be present
+	optionalOID := append(prefix, 8)
+	for _, e := range exts {
+		if e.Id.String() == optionalOID.String() {
+			t.Fatalf("did not expect optional extension to be present")
+		}
+	}
+
+	// Decode should leave Optional nil
+	var out HostAttrs
+	if err := Decode(prefix, exts, &out); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if out.Optional != nil {
+		t.Fatalf("expected out.Optional nil")
+	}
+}
+
+func TestRequireAll(t *testing.T) {
+	prefix := asn1.ObjectIdentifier{1, 2, 3}
+
+	// Only include one extension
+	only := []pkix.Extension{
+		{Id: append(prefix, 1), Critical: true, Value: mustDER(t, "node")},
+	}
+
+	var out HostAttrs
+	err := Decode(prefix, only, &out, WithDecodeRequireAll())
+	if err == nil {
+		t.Fatalf("expected error due to missing required fields")
+	}
+}
+
+func TestIgnoreUntagged(t *testing.T) {
+	type WithExtra struct {
+		A string `oid:"1"`
+		B string // untagged
+	}
+
+	prefix := asn1.ObjectIdentifier{9, 9, 9}
+	in := WithExtra{A: "x", B: "y"}
+
+	_, err := Encode(prefix, in)
+	if err == nil {
+		t.Fatalf("expected error for missing oid tag when IgnoreUntagged=false")
+	}
+
+	exts, err := Encode(prefix, in, WithEncodeIgnoreUntagged())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(exts) != 1 {
+		t.Fatalf("expected 1 extension, got %d", len(exts))
+	}
+}
+
+func mustDER(t *testing.T, s string) []byte {
+	t.Helper()
+	der, err := asn1.Marshal(s)
+	if err != nil {
+		t.Fatalf("asn1.Marshal: %v", err)
+	}
+	return der
+}
+
+func TestFloatEncoding(t *testing.T) {
+	type Floats struct {
+		F32 float32 `oid:"1"`
+		F64 float64 `oid:"2"`
+	}
+
+	prefix := asn1.ObjectIdentifier{1, 2, 3}
+
+	in := Floats{
+		F32: 3.1415927,
+		F64: 2.718281828459045,
+	}
+
+	exts, err := Encode(prefix, in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	var out Floats
+	if err := Decode(prefix, exts, &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if in.F32 != out.F32 {
+		t.Fatalf("float32 mismatch: %v vs %v", in.F32, out.F32)
+	}
+	if in.F64 != out.F64 {
+		t.Fatalf("float64 mismatch: %v vs %v", in.F64, out.F64)
+	}
+}


### PR DESCRIPTION
This PR introduces the oidext package which provides a structured, deterministic mapping between Go structs and ASN.1 OID-based X.509 extensions.

It is intended for use with X.509 certificates and certificate signing requests (CSRs) where additional, application-specific metadata must be encoded as standards-compliant extensions.

Each exported struct field is mapped to a unique Object Identifier (OID), constructed by appending a field-specific suffix (declared via struct tags) to a caller-supplied prefix OID. Field values are ASN.1 DER-encoded using Go’s encoding/asn1 package and emitted as pkix.Extension values.

The package supports round-trip encoding and decoding, critical extensions, optional fields, nested structs, and deterministic extension ordering. It deliberately avoids implicit behavior and schema inference, favouring explicit OID assignment and strong typing.

Typical use cases include private PKI extensions, CSR metadata injection, workload or host identity attributes, licensing claims, and platform-specific certificate annotations.

