### PR TITLE
feat: Add support for additional kingkong sections

### DIFF
--- a/kingkong/help.go
+++ b/kingkong/help.go
@@ -30,10 +30,13 @@ const (
 )
 
 var (
-	Underline    = lipgloss.NewStyle().Underline(true).Render
-	EnvVarColor  = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: string(colors.Emerald500), Dark: string(colors.Emerald200)}).Render
-	CommandColor = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: string(colors.Blue500), Dark: string(colors.Blue200)}).Render
-	DimmedColor  = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: string(colors.Slate500), Dark: string(colors.Slate200)}).Render
+	Underline = lipgloss.NewStyle().Underline(true).Render
+	Bold      = lipgloss.NewStyle().Bold(true).Render
+
+	EnvVarColor     = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: string(colors.Emerald500), Dark: string(colors.Emerald200)}).Render
+	CommandColor    = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: string(colors.Blue500), Dark: string(colors.Blue200)}).Render
+	DimmedColor     = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: string(colors.Slate500), Dark: string(colors.Slate300)}).Render
+	DimmedMoreColor = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: string(colors.Slate400), Dark: string(colors.Slate400)}).Render
 )
 
 // HelpPrinter returns a function implementation of kong.HelpPrinter.
@@ -235,6 +238,12 @@ func printNodeDetail(w *helpWriter, node *kong.Node, hide bool) {
 				}
 			}
 		}
+	}
+
+	for _, section := range getAdditionalSections(node) {
+		w.Print("")
+		w.Print(Underline(section.Title) + ":")
+		w.Indent().Wrap(section.Content)
 	}
 
 	if w.FlagsLast {
@@ -463,4 +472,12 @@ func formatEnvs(envs []string) string {
 	}
 
 	return strings.Join(formatted, ", ")
+}
+
+func getAdditionalSections(node *kong.Node) []HelpSection {
+	help, ok := node.Target.Interface().(AdditionalHelp)
+	if !ok {
+		return nil
+	}
+	return help.HelpSections()
 }

--- a/kingkong/types.go
+++ b/kingkong/types.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package kingkong
+
+type AdditionalHelp interface {
+	HelpSections() []HelpSection
+}
+
+type HelpSection struct {
+	// Title is the title of the help section.
+	Title string
+	// Content contains the help section content.
+	Content string
+}


### PR DESCRIPTION
We want to render new sections specifically for kingkong. kingkong should style the sections, but we want the underlying application to be able to determine what's in the sections and where they're attached.