### PR TITLE
feat(log): Add logrus adapter

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -305,6 +305,7 @@ github.com/securego/gosec/v2 v2.19.0/go.mod h1:hOkDcHz9J/XIgIlPDXalxjeVYsHxoWUc5
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAxekIXwN8qQyfc5gl2NlkB3CQlkizAbOkeBs=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sivchari/containedctx v1.0.3/go.mod h1:c1RDvCbnJLtH4lLcYD/GqwiBSSf4F5Qk0xld2rBqzJ4=
 github.com/sivchari/tenv v1.7.1/go.mod h1:64yStXKSOxDfX47NlhVwND4dHwfZDdbp2Lyl018Icvg=

--- a/log/go.mod
+++ b/log/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/buger/jsonparser v1.1.1
 	github.com/getsentry/sentry-go v0.41.0
 	github.com/rs/zerolog v1.34.0
+	github.com/sirupsen/logrus v1.9.4
 )
 
 require (

--- a/log/go.sum
+++ b/log/go.sum
@@ -25,6 +25,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
+github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
+github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/log/logrus.go
+++ b/log/logrus.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package log
+
+import (
+	"errors"
+
+	"github.com/rs/zerolog"
+	"github.com/sirupsen/logrus"
+)
+
+func ToLogrus(l *Logger) *logrus.Logger {
+	logger := logrus.New()
+	// format all the logrus logs using zerolog
+	logger.SetFormatter(logFormatter{l})
+	// crank the log level to the max so all logs are passed to zerolog
+	logger.SetLevel(logrus.TraceLevel)
+	return logger
+}
+
+type logFormatter struct {
+	l *Logger
+}
+
+func (f logFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	var e *zerolog.Event
+
+	switch entry.Level {
+	case logrus.TraceLevel:
+		e = f.l.Trace()
+	case logrus.DebugLevel:
+		e = f.l.Debug()
+	case logrus.InfoLevel:
+		e = f.l.Info()
+	case logrus.WarnLevel:
+		e = f.l.Warn()
+	case logrus.ErrorLevel:
+		e = f.l.Error()
+	case logrus.FatalLevel:
+		e = f.l.Error() // nothing should be fatal
+	default:
+		return nil, errors.New("unknown log level")
+	}
+
+	for k, v := range entry.Data {
+		switch k {
+		// drop some fields
+		case "go.version":
+		default:
+			e = e.Any(k, v)
+		}
+	}
+
+	// log here
+	e.Msg(entry.Message)
+
+	// drop the entry
+	return nil, nil
+}


### PR DESCRIPTION
Mostly extracted from the agent: https://github.com/unikraft-cloud/agent/blob/b34ba5eca3d238f3a6dc6579ad250ef8816608b4/internal/registry/registry.go#L55

However, I need this for the new CLI, in the places where we interact with buildkit + containerd, since those logs are all based on logrus.