### PR TITLE
refactor(kingking)!: Prettify the examples help output

### DIFF
--- a/kingkong/examples.go
+++ b/kingkong/examples.go
@@ -9,7 +9,7 @@ package kingkong
 // of the example and the second being the code snippet.
 type Example struct {
 	Description string
-	Command     string
+	Commands    []string
 }
 
 // ExamplesProvider is an interface that defines a method to return examples for

--- a/kingkong/help.go
+++ b/kingkong/help.go
@@ -244,9 +244,21 @@ func printNodeDetail(w *helpWriter, node *kong.Node, hide bool) {
 		w.Print("")
 		w.Print(Underline("Examples") + ":")
 
+		comment := &helpWriter{
+			indent:      DimmedMoreColor(w.indent + "  # "),
+			lines:       w.lines,
+			width:       w.width - 4,
+			HelpOptions: w.HelpOptions,
+		}
+
 		for _, example := range examples {
-			w.Indent().Wrap(example.Description)
+			for _, line := range strings.Split(strings.TrimSpace(ansi.Wrap(strings.TrimSpace(example.Description), comment.width, "-")), "\n") {
+				comment.Print(DimmedMoreColor(line))
+			}
 			w.Indent().Wrap(example.Command)
+			if example != examples[len(examples)-1] {
+				w.Print("")
+			}
 		}
 	}
 

--- a/kingkong/help.go
+++ b/kingkong/help.go
@@ -251,12 +251,14 @@ func printNodeDetail(w *helpWriter, node *kong.Node, hide bool) {
 			HelpOptions: w.HelpOptions,
 		}
 
-		for _, example := range examples {
+		for i, example := range examples {
 			for _, line := range strings.Split(strings.TrimSpace(ansi.Wrap(strings.TrimSpace(example.Description), comment.width, "-")), "\n") {
 				comment.Print(DimmedMoreColor(line))
 			}
-			w.Indent().Wrap(example.Command)
-			if example != examples[len(examples)-1] {
+			for _, command := range example.Commands {
+				w.Indent().Wrap(command)
+			}
+			if i != len(examples)-1 {
 				w.Print("")
 			}
 		}


### PR DESCRIPTION
Adds a markdown-style comment in front of the description,
dims the comment too and adds extra spacing between the
examples. 

Adds also the ability to supply multiple commands in a
single example.

Signed-off-by: Alexander Jung <alex@unikraft.com>
