### PR TITLE
ci: Formalize `actionlint` & `check-pr` into actions

### DIFF
--- a/.github/actions/actionlint/action.yaml
+++ b/.github/actions/actionlint/action.yaml
@@ -1,0 +1,16 @@
+name: actionlint
+
+description: Lint the syntax changes of a GitHub Actions workflow file.
+
+runs:
+  using: composite
+  steps:
+  - name: Install action linter
+    shell: bash
+    run: |
+      mkdir -p "$HOME"/.local/bin
+      curl -sL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest "$HOME"/.local/bin
+
+  - name: Check that all workflows are valid
+    shell: bash
+    run: actionlint -verbose

--- a/.github/actions/check-pr/action.yaml
+++ b/.github/actions/check-pr/action.yaml
@@ -1,0 +1,50 @@
+name: check-pr
+
+description: Common steps for checking the format of PRs.
+
+runs:
+  using: composite
+  steps:
+  - name: Fetch commitlint config
+    env:
+      GIT_REPO: unikraft-cloud/x
+      GIT_REF: prod-staging
+    shell: bash
+    run: |
+      if [ ! -f commitlint.config.mjs ]; then
+        wget "https://raw.githubusercontent.com/${GIT_REPO}/${GIT_REF}/commitlint.config.mjs"
+      fi
+      if [ ! -f package.json ]; then
+        wget "https://raw.githubusercontent.com/${GIT_REPO}/${GIT_REF}/package.json"
+      fi
+      if [ ! -f package-lock.json ]; then
+        wget "https://raw.githubusercontent.com/${GIT_REPO}/${GIT_REF}/package-lock.json"
+      fi
+
+  - name: Setup node
+    uses: actions/setup-node@v6
+    with:
+      node-version: lts/*
+      cache: npm
+
+  - name: Setup commitlint
+    shell: bash
+    run: npm install --include=dev
+
+  - name: Validate commits
+    id: validate-commits
+    shell: bash
+    run: |
+      npx commitlint \
+        --verbose \
+        --from ${{ github.event.pull_request.base.sha }} \
+        --to ${{ github.event.pull_request.head.sha }}
+
+  - name: Validate PR
+    id: validate-pr
+    if: ${{ (steps.validate-commits.outcome == 'success' || steps.validate-commits.outcome == 'failure') && github.actor != 'dependabot' && github.actor != 'dependabot[bot]' }}
+    env:
+      TITLE: ${{ github.event.pull_request.title }}
+    shell: bash
+    run: |
+      echo "$TITLE" | PR=yes npx commitlint --verbose

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -15,12 +15,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+    - uses: actions/checkout@v5
 
-      - name: Install action linter
-        run: |
-          mkdir -p "$HOME"/.local/bin
-          curl -sL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest "$HOME"/.local/bin
-
-      - name: Check that all workflows are valid
-        run: actionlint -verbose
+    - name: Run actionlint
+      uses: ./.github/actions/actionlint

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -1,4 +1,4 @@
-name: check/pr
+name: check-pr
 
 on:
   pull_request:
@@ -8,49 +8,12 @@ on:
   workflow_call:
 
 jobs:
-  commitlint:
+  check-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-      - name: Fetch commitlint config
-        run: |
-          if [ ! -f commitlint.config.mjs ]; then
-            wget "https://raw.githubusercontent.com/${GIT_REPO}/${GIT_REF}/commitlint.config.mjs"
-          fi
-          if [ ! -f package.json ]; then
-            wget "https://raw.githubusercontent.com/${GIT_REPO}/${GIT_REF}/package.json"
-          fi
-          if [ ! -f package-lock.json ]; then
-            wget "https://raw.githubusercontent.com/${GIT_REPO}/${GIT_REF}/package-lock.json"
-          fi
-        env:
-          GIT_REPO: unikraft-cloud/x
-          GIT_REF: prod-staging
-
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-          cache: npm
-
-      - name: Setup commitlint
-        run: npm install --include=dev
-
-      - name: Validate commits
-        id: validate-commits
-        run: |
-          npx commitlint \
-            --verbose \
-            --from ${{ github.event.pull_request.base.sha }} \
-            --to ${{ github.event.pull_request.head.sha }}
-
-      - name: Validate PR
-        id: validate-pr
-        if: ${{ (steps.validate-commits.outcome == 'success' || steps.validate-commits.outcome == 'failure') && github.actor != 'dependabot' && github.actor != 'dependabot[bot]' }}
-        run: |
-          echo "$TITLE" | PR=yes npx commitlint --verbose
-        env:
-          TITLE: ${{ github.event.pull_request.title }}
+    - name: Run check-pr
+      uses: ./.github/actions/check-pr


### PR DESCRIPTION
This PR rips out the logic from the `actionlint` and `check-pr` workflow and places them into reusable composite actions. This allows the individual actions to be used externally.