### PR TITLE
feat(taskfile)!: Disable link mode external

### DIFF
--- a/Taskfile.go.yml
+++ b/Taskfile.go.yml
@@ -73,7 +73,7 @@ tasks:
       go_ldflags_extra:
         ref: .go_ldflags_extra | default ""
       go_ldflags: >-
-        {{- ternary "" "-s -w -linkmode external -extldflags -static-pie" .go_debug }}
+        {{- ternary "" "-s -w -extldflags -static-pie" .go_debug }}
         -X "{{.go_module}}/internal/version.Version={{.version}}"
         -X "{{.go_module}}/internal/version.Commit={{.git_sha}}"
         -X "{{.go_module}}/internal/version.BuildTime={{now}}"


### PR DESCRIPTION
This can be provided as an optional ldflag if necessary; otherwise prefer Go's internal linker.