### PR TITLE
feat(image-spec): Expose APIs working with content.Ingester/Provider

### DIFF
--- a/image-spec/ctrd_load.go
+++ b/image-spec/ctrd_load.go
@@ -20,7 +20,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func loadCtrdImage(ctx context.Context, store content.Provider, desc ocispec.Descriptor) (*Image, error) {
+func LoadContent(ctx context.Context, store content.Provider, desc ocispec.Descriptor) (*Image, error) {
 	img := &Image{
 		Provider:   store,
 		Descriptor: desc,

--- a/image-spec/ctrd_save.go
+++ b/image-spec/ctrd_save.go
@@ -27,7 +27,7 @@ import (
 	"unikraft.com/x/log"
 )
 
-func saveCtrdImage(ctx context.Context, store content.Ingester, ref string, image *Image) (ocispec.Descriptor, error) {
+func SaveContent(ctx context.Context, store content.Ingester, ref string, image *Image) (ocispec.Descriptor, error) {
 	store = ingestDefaults(store, content.WithRef(ref))
 
 	eg, egCtx := errgroup.WithContext(ctx)

--- a/image-spec/storage_archive.go
+++ b/image-spec/storage_archive.go
@@ -52,7 +52,7 @@ func LoadTarballReader(ctx context.Context, r io.Reader) (_ *Image, rerr error) 
 		return nil, fmt.Errorf("failed to import tarball: %w", err)
 	}
 
-	img, err := loadCtrdImage(ctx, store, idxDesc)
+	img, err := LoadContent(ctx, store, idxDesc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load image from imported tarball: %w", err)
 	}
@@ -84,7 +84,7 @@ func SaveTarballWriter(ctx context.Context, w io.Writer, image *Image) error {
 		return fmt.Errorf("failed to create local store: %w", err)
 	}
 
-	desc, err := saveCtrdImage(ctx, store, "latest", image)
+	desc, err := SaveContent(ctx, store, "latest", image)
 	if err != nil {
 		return fmt.Errorf("failed to save image to local store: %w", err)
 	}

--- a/image-spec/storage_docker.go
+++ b/image-spec/storage_docker.go
@@ -38,7 +38,7 @@ func LoadDockerImage(ctx context.Context, named reference.Named, remote remotes.
 	}
 	provider := contentutil.FromFetcher(fetcher)
 
-	img, err := loadCtrdImage(ctx, provider, desc)
+	img, err := LoadContent(ctx, provider, desc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load image %q: %w", named, err)
 	}
@@ -56,7 +56,7 @@ func SaveDockerImage(ctx context.Context, named reference.Named, remote remotes.
 	}
 	ingester := contentutil.FromPusher(pusher)
 
-	desc, err := saveCtrdImage(ctx, ingester, named.Name(), image)
+	desc, err := SaveContent(ctx, ingester, named.Name(), image)
 	if err != nil {
 		return nil, ocispec.Descriptor{}, fmt.Errorf("failed to save image %q: %w", named, err)
 	}

--- a/image-spec/storage_layout.go
+++ b/image-spec/storage_layout.go
@@ -19,7 +19,7 @@ func LoadOCILayout(ctx context.Context, path string, desc ocispec.Descriptor) (*
 	if err != nil {
 		return nil, fmt.Errorf("failed to open content store at %q: %w", path, err)
 	}
-	return loadCtrdImage(ctx, store, desc)
+	return LoadContent(ctx, store, desc)
 }
 
 func LoadOCILayoutNamed(ctx context.Context, path string, tag string) (*Image, error) {
@@ -40,7 +40,7 @@ func LoadOCILayoutNamed(ctx context.Context, path string, tag string) (*Image, e
 		return nil, fmt.Errorf("failed to open content store at %q: %w", path, err)
 	}
 
-	return loadCtrdImage(ctx, store, *desc)
+	return LoadContent(ctx, store, *desc)
 }
 
 func SaveOCILayout(ctx context.Context, path string, tag string, image *Image) (ocispec.Descriptor, error) {
@@ -48,7 +48,7 @@ func SaveOCILayout(ctx context.Context, path string, tag string, image *Image) (
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("failed to open content store at %q: %w", path, err)
 	}
-	return saveCtrdImage(ctx, store, tag, image)
+	return SaveContent(ctx, store, tag, image)
 }
 
 func SaveOCILayoutNamed(ctx context.Context, path string, tag string, image *Image) (ocispec.Descriptor, error) {
@@ -58,7 +58,7 @@ func SaveOCILayoutNamed(ctx context.Context, path string, tag string, image *Ima
 	}
 	idx := ociindex.NewStoreIndex(path)
 
-	desc, err := saveCtrdImage(ctx, store, tag, image)
+	desc, err := SaveContent(ctx, store, tag, image)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("failed to save ctrd image: %w", err)
 	}


### PR DESCRIPTION
This allows the agent to build it's image handling logic around the
containerd content.Store interface.

Signed-off-by: Robert Günzler <robert@unikraft.cloud>
