### PR TITLE
feat: Allow deleting images with imgspec

### DIFF
--- a/image-spec/accessor.go
+++ b/image-spec/accessor.go
@@ -75,7 +75,7 @@ func (accessor *Accessor) Load(ctx context.Context, src *URI, platform platforms
 		if err != nil {
 			return nil, fmt.Errorf("parsing image reference %q: %w", src, err)
 		}
-		return LoadDockerImage(ctx, named, accessor.remote, platform)
+		return LoadRegistryImage(ctx, named, accessor.remote, platform)
 	case URISchemeOCILayout:
 		path, tag := parsePathTag(src.Path)
 		return LoadOCILayoutNamed(ctx, path, tag, platform)
@@ -93,7 +93,7 @@ func (accessor *Accessor) LoadAll(ctx context.Context, src *URI, platform platfo
 		if err != nil {
 			return nil, fmt.Errorf("parsing image reference %q: %w", src, err)
 		}
-		return LoadAllDockerImages(ctx, named, accessor.remote, platform)
+		return LoadAllRegistryImages(ctx, named, accessor.remote, platform)
 	case URISchemeOCILayout:
 		path, tag := parsePathTag(src.Path)
 		return LoadAllOCILayoutsNamed(ctx, path, tag, platform)
@@ -111,7 +111,7 @@ func (accessor *Accessor) Save(ctx context.Context, dest *URI, img ...*Image) er
 		if err != nil {
 			return fmt.Errorf("parsing image reference %q: %w", dest, err)
 		}
-		_, _, err = SaveDockerImage(ctx, named, accessor.remote, img...)
+		_, _, err = SaveRegistryImage(ctx, named, accessor.remote, img...)
 		return err
 	case URISchemeOCILayout:
 		path, tag := parsePathTag(dest.Path)
@@ -137,7 +137,7 @@ func (accessor *Accessor) Delete(ctx context.Context, target *URI) error {
 		if err != nil {
 			return fmt.Errorf("parsing image reference %q: %w", target, err)
 		}
-		return DeleteDockerImage(ctx, named, accessor.remote, accessor.registryHosts, accessor.registryHeaders)
+		return DeleteRegistryImage(ctx, named, accessor.remote, accessor.registryHosts, accessor.registryHeaders)
 	case URISchemeOCILayout:
 		path, tag := parsePathTag(target.Path)
 		if tag == "" {

--- a/image-spec/accessor.go
+++ b/image-spec/accessor.go
@@ -8,6 +8,8 @@ package imagespec
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os"
 
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
@@ -16,8 +18,10 @@ import (
 )
 
 type Accessor struct {
-	remote    remotes.Resolver
-	refParser func(string) (reference.Named, error)
+	remote          remotes.Resolver
+	registryHosts   docker.RegistryHosts
+	registryHeaders http.Header
+	refParser       func(string) (reference.Named, error)
 }
 
 func NewAccessor(opts ...AccessOpt) *Accessor {
@@ -39,6 +43,22 @@ type AccessOpt func(*Accessor)
 func WithResolver(r remotes.Resolver) AccessOpt {
 	return func(so *Accessor) {
 		so.remote = r
+	}
+}
+
+func WithRegistryHosts(hosts docker.RegistryHosts) AccessOpt {
+	return func(so *Accessor) {
+		so.registryHosts = hosts
+	}
+}
+
+func WithRegistryHeaders(headers http.Header) AccessOpt {
+	return func(so *Accessor) {
+		if headers == nil {
+			so.registryHeaders = nil
+			return
+		}
+		so.registryHeaders = headers.Clone()
 	}
 }
 
@@ -104,5 +124,29 @@ func (accessor *Accessor) Save(ctx context.Context, dest *URI, img ...*Image) er
 		return SaveTarball(ctx, dest.Path, img...)
 	default:
 		return fmt.Errorf("unsupported URI scheme: %q", dest.Scheme)
+	}
+}
+
+func (accessor *Accessor) Delete(ctx context.Context, target *URI) error {
+	switch target.Scheme {
+	case URISchemeOCI:
+		if accessor.registryHosts == nil {
+			return fmt.Errorf("no registry hosts configured for %q", target.Path)
+		}
+		named, err := accessor.refParser(target.Path)
+		if err != nil {
+			return fmt.Errorf("parsing image reference %q: %w", target, err)
+		}
+		return DeleteDockerImage(ctx, named, accessor.remote, accessor.registryHosts, accessor.registryHeaders)
+	case URISchemeOCILayout:
+		path, tag := parsePathTag(target.Path)
+		if tag == "" {
+			return os.RemoveAll(path)
+		}
+		return DeleteOCILayoutNamed(path, tag)
+	case URISchemeOCIArchive:
+		return os.Remove(target.Path)
+	default:
+		return fmt.Errorf("unsupported URI scheme: %q", target.Scheme)
 	}
 }

--- a/image-spec/backend_archive.go
+++ b/image-spec/backend_archive.go
@@ -17,6 +17,12 @@ import (
 	"github.com/containerd/platforms"
 )
 
+// This files provides functions for loading and saving images to/from tarball files using
+// containerd's archive package.
+//
+// This is convenient for moving images around, as well as an intermediate
+// format for building images before pushing them.
+
 // LoadTarball loads an image from a tarball (OCI or Docker format).
 func LoadTarball(ctx context.Context, tarballPath string, platform platforms.MatchComparer) (*Image, error) {
 	f, err := os.Open(tarballPath)

--- a/image-spec/backend_docker.go
+++ b/image-spec/backend_docker.go
@@ -7,12 +7,20 @@ package imagespec
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
+	"path"
 
 	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	ctrdreference "github.com/containerd/containerd/v2/pkg/reference"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	"github.com/moby/buildkit/util/contentutil"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -95,4 +103,198 @@ func SaveDockerImage(ctx context.Context, named reference.Named, remote remotes.
 		return nil, ocispec.Descriptor{}, fmt.Errorf("failed to save image %q: %w", named, err)
 	}
 	return named, desc, nil
+}
+
+// DeleteDockerImage deletes a Docker image from a remote registry.
+func DeleteDockerImage(ctx context.Context, named reference.Named, remote remotes.Resolver, hosts docker.RegistryHosts, headers http.Header) error {
+	named = reference.TagNameOnly(named)
+
+	name, desc, err := remote.Resolve(ctx, named.String())
+	if err != nil {
+		return fmt.Errorf("failed to resolve image %q: %w", named, err)
+	}
+	if desc.Digest == "" {
+		return fmt.Errorf("resolved image %q without digest", named)
+	}
+	if err := desc.Digest.Validate(); err != nil {
+		return fmt.Errorf("resolved image %q with invalid digest: %w", named, err)
+	}
+	refspec, err := ctrdreference.Parse(name)
+	if err != nil {
+		return fmt.Errorf("failed to parse resolved image reference %q: %w", name, err)
+	}
+	ctx, err = docker.ContextWithRepositoryScope(ctx, refspec, true)
+	if err != nil {
+		return err
+	}
+
+	ref, err := reference.Parse(name)
+	if err != nil {
+		return fmt.Errorf("failed to parse resolved image name %q: %w", name, err)
+	}
+	resolved, ok := ref.(reference.Named)
+	if !ok {
+		return fmt.Errorf("resolved image name %q is not a named reference", name)
+	}
+	if hosts == nil {
+		return fmt.Errorf("no registry hosts configured for %q", resolved)
+	}
+
+	refHost := reference.Domain(resolved)
+	repository := reference.Path(resolved)
+	if repository == "" {
+		return fmt.Errorf("resolved image name %q has empty repository", name)
+	}
+
+	registryHosts, err := hosts(refHost)
+	if err != nil {
+		return fmt.Errorf("failed to resolve registry hosts for %q: %w", refHost, err)
+	}
+	if len(registryHosts) == 0 {
+		return fmt.Errorf("no registry hosts available for %q", refHost)
+	}
+	deleteHosts := filterHostsByCapability(registryHosts, docker.HostCapabilityPush)
+	if len(deleteHosts) == 0 {
+		deleteHosts = registryHosts
+	}
+
+	var firstErr error
+	for _, host := range deleteHosts {
+		err := deleteDockerManifest(ctx, host, headers, refHost, repository, desc.Digest)
+		if err == nil {
+			return nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func filterHostsByCapability(hosts []docker.RegistryHost, cap docker.HostCapabilities) []docker.RegistryHost {
+	filtered := make([]docker.RegistryHost, 0, len(hosts))
+	for _, host := range hosts {
+		if host.Capabilities.Has(cap) {
+			filtered = append(filtered, host)
+		}
+	}
+	return filtered
+}
+
+func deleteDockerManifest(ctx context.Context, host docker.RegistryHost, headers http.Header, refHost string, repository string, dgst digest.Digest) error {
+	requestHeaders := http.Header{}
+	if headers != nil {
+		requestHeaders = headers.Clone()
+	}
+	for key, values := range host.Header {
+		requestHeaders[key] = append(requestHeaders[key], values...)
+	}
+
+	deleteURL := url.URL{
+		Scheme: host.Scheme,
+		Host:   host.Host,
+		Path:   path.Join("/", host.Path, repository, "manifests", dgst.String()),
+	}
+	addNamespace(&deleteURL, refHost, host.Host)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, deleteURL.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header = requestHeaders
+
+	client := &http.Client{}
+	if host.Client != nil {
+		*client = *host.Client
+	}
+	if client.CheckRedirect == nil {
+		// Mimic containerd's resolver redirect handling.
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errors.New("stopped after 10 redirects")
+			}
+			if host.Authorizer != nil {
+				if err := host.Authorizer.Authorize(ctx, req); err != nil {
+					return fmt.Errorf("failed to authorize redirect: %w", err)
+				}
+			}
+			return nil
+		}
+	}
+
+	resp, err := doDeleteRequest(ctx, client, req, host.Authorizer)
+	if err != nil {
+		return err
+	}
+	if resp.Body != nil {
+		resp.Body.Close()
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("manifest %s not found: %w", dgst.String(), errdefs.ErrNotFound)
+	}
+	return fmt.Errorf("delete request failed: %s", resp.Status)
+}
+
+// doDeleteRequest mirrors containerd's retry/authorize request flow.
+// Source: github.com/containerd/containerd/v2/core/remotes/docker/resolver.go
+func doDeleteRequest(ctx context.Context, client *http.Client, req *http.Request, authorizer docker.Authorizer) (*http.Response, error) {
+	const maxAttempts = 5
+	var responses []*http.Response
+	for range maxAttempts {
+		cloned := req.Clone(ctx)
+		if req.Header != nil {
+			cloned.Header = req.Header.Clone()
+		} else {
+			cloned.Header = http.Header{}
+		}
+		if authorizer != nil {
+			if err := authorizer.Authorize(ctx, cloned); err != nil {
+				return nil, fmt.Errorf("failed to authorize: %w", err)
+			}
+		}
+		resp, err := client.Do(cloned)
+		if err != nil {
+			return nil, fmt.Errorf("failed to do request: %w", err)
+		}
+		if resp.StatusCode != http.StatusUnauthorized {
+			return resp, nil
+		}
+		responses = append(responses, resp)
+		resp.Body.Close()
+		if authorizer == nil {
+			return resp, nil
+		}
+		if err := authorizer.AddResponses(ctx, responses); err != nil {
+			if errdefs.IsNotImplemented(err) {
+				return resp, nil
+			}
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("authorization failed after %d attempts", maxAttempts)
+}
+
+// isProxy mirrors containerd's RegistryHost.isProxy logic.
+// Source: github.com/containerd/containerd/v2/core/remotes/docker/registry.go
+func isProxy(refHost string, registryHost string) bool {
+	if refHost != registryHost {
+		if refHost != "docker.io" || registryHost != "registry-1.docker.io" {
+			return true
+		}
+	}
+	return false
+}
+
+// addNamespace mirrors containerd's request.addNamespace behavior.
+// Source: github.com/containerd/containerd/v2/core/remotes/docker/resolver.go
+func addNamespace(target *url.URL, refHost string, registryHost string) {
+	if !isProxy(refHost, registryHost) {
+		return
+	}
+	query := target.Query()
+	query.Set("ns", refHost)
+	target.RawQuery = query.Encode()
 }

--- a/image-spec/backend_layout.go
+++ b/image-spec/backend_layout.go
@@ -7,10 +7,16 @@ package imagespec
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
 
 	"github.com/containerd/containerd/v2/plugins/content/local"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
+	"github.com/gofrs/flock"
 	"github.com/moby/buildkit/client/ociindex"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -100,3 +106,74 @@ func SaveOCILayoutNamed(ctx context.Context, path string, tag string, image ...*
 
 	return desc, nil
 }
+
+func DeleteOCILayoutNamed(path string, tag string) error {
+	if tag == "" {
+		return fmt.Errorf("empty tag for OCI layout delete")
+	}
+
+	// HACK: ociindex doesn't support deleting manifests, so we need to
+	// manually read, modify, and write the index. We take the same lock that
+	// ociindex uses to ensure consistency with other operations.
+	indexPath := filepath.Join(path, ocispec.ImageIndexFile)
+	lockPath := indexPath + ".lock"
+	lock := flock.New(lockPath)
+	locked, err := lock.TryLock()
+	if err != nil {
+		return fmt.Errorf("could not lock %s: %w", lockPath, err)
+	}
+	if !locked {
+		return fmt.Errorf("could not lock %s", lockPath)
+	}
+	defer func() {
+		_ = lock.Unlock()
+		os.RemoveAll(lockPath)
+	}()
+
+	indexData, err := os.ReadFile(indexPath)
+	if err != nil {
+		return fmt.Errorf("failed to read OCI index at %q: %w", path, err)
+	}
+	var index ocispec.Index
+	if err := json.Unmarshal(indexData, &index); err != nil {
+		return fmt.Errorf("failed to unmarshal OCI index at %q: %w", path, err)
+	}
+
+	originalLen := len(index.Manifests)
+	index.Manifests = slices.DeleteFunc(index.Manifests, func(manifest ocispec.Descriptor) bool {
+		return matchesOCITag(manifest, tag)
+	})
+	if len(index.Manifests) == originalLen {
+		return fmt.Errorf("tag %q not found in OCI layout %q: %w", tag, path, errdefs.ErrNotFound)
+	}
+	if index.SchemaVersion == 0 {
+		index.SchemaVersion = 2
+	}
+	if index.MediaType == "" {
+		index.MediaType = ocispec.MediaTypeImageIndex
+	}
+
+	indexData, err = json.Marshal(index)
+	if err != nil {
+		return fmt.Errorf("failed to marshal OCI index: %w", err)
+	}
+	if err := os.WriteFile(indexPath, indexData, 0o644); err != nil {
+		return fmt.Errorf("failed to write OCI index %q: %w", indexPath, err)
+	}
+	return nil
+}
+
+func matchesOCITag(desc ocispec.Descriptor, tag string) bool {
+	if desc.Annotations == nil {
+		return false
+	}
+	if desc.Annotations[ocispec.AnnotationRefName] == tag {
+		return true
+	}
+	if desc.Annotations[ociContainerdImageNameAnnotation] == tag {
+		return true
+	}
+	return false
+}
+
+const ociContainerdImageNameAnnotation = "io.containerd.image.name"

--- a/image-spec/backend_layout.go
+++ b/image-spec/backend_layout.go
@@ -21,6 +21,12 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+// This file provides functions for loading and saving images to/from OCI layouts.
+// This implements the OCI image layout spec at https://github.com/opencontainers/image-spec/blob/main/image-layout.md
+//
+// This is essentially equivalent to the tarball archive loaders/savers, but
+// unpacked and managing an index file. It's very useful for debugging :)
+
 func LoadOCILayout(ctx context.Context, path string, desc ocispec.Descriptor, platform platforms.MatchComparer) (*Image, error) {
 	store, err := local.NewStore(path)
 	if err != nil {

--- a/image-spec/backend_registry.go
+++ b/image-spec/backend_registry.go
@@ -24,8 +24,15 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// LoadDockerImage loads a Docker image from a remote registry.
-func LoadDockerImage(ctx context.Context, named reference.Named, remote remotes.Resolver, platform platforms.MatchComparer) (*Image, error) {
+// This file provides functions for loading and saving images to/from remote
+// registries using containerd's remotes package. This implements the
+// underlying distribution spec at https://github.com/opencontainers/distribution-spec.
+//
+// This is the standard way to interact with a unikraft image, both the ones in
+// our global harbor (at index.unikraft.io), as well as direct push.
+
+// LoadRegistryImage loads a image from a remote registry.
+func LoadRegistryImage(ctx context.Context, named reference.Named, remote remotes.Resolver, platform platforms.MatchComparer) (*Image, error) {
 	named = reference.TagNameOnly(named)
 
 	name, desc, err := remote.Resolve(ctx, named.String())
@@ -55,8 +62,8 @@ func LoadDockerImage(ctx context.Context, named reference.Named, remote remotes.
 	return img, nil
 }
 
-// LoadAllDockerImages loads all available Docker images from a remote registry.
-func LoadAllDockerImages(ctx context.Context, named reference.Named, remote remotes.Resolver, platform platforms.MatchComparer) ([]*Image, error) {
+// LoadAllRegistryImages loads all available images from a remote registry.
+func LoadAllRegistryImages(ctx context.Context, named reference.Named, remote remotes.Resolver, platform platforms.MatchComparer) ([]*Image, error) {
 	named = reference.TagNameOnly(named)
 
 	name, desc, err := remote.Resolve(ctx, named.String())
@@ -88,8 +95,8 @@ func LoadAllDockerImages(ctx context.Context, named reference.Named, remote remo
 	return imgs, nil
 }
 
-// SaveDockerImage saves a Docker image to a remote registry.
-func SaveDockerImage(ctx context.Context, named reference.Named, remote remotes.Resolver, image ...*Image) (reference.Named, ocispec.Descriptor, error) {
+// SaveRegistryImage saves a image to a remote registry.
+func SaveRegistryImage(ctx context.Context, named reference.Named, remote remotes.Resolver, image ...*Image) (reference.Named, ocispec.Descriptor, error) {
 	named = reference.TagNameOnly(named)
 
 	pusher, err := remote.Pusher(ctx, named.String())
@@ -105,8 +112,8 @@ func SaveDockerImage(ctx context.Context, named reference.Named, remote remotes.
 	return named, desc, nil
 }
 
-// DeleteDockerImage deletes a Docker image from a remote registry.
-func DeleteDockerImage(ctx context.Context, named reference.Named, remote remotes.Resolver, hosts docker.RegistryHosts, headers http.Header) error {
+// DeleteRegistryImage deletes a image from a remote registry.
+func DeleteRegistryImage(ctx context.Context, named reference.Named, remote remotes.Resolver, hosts docker.RegistryHosts, headers http.Header) error {
 	named = reference.TagNameOnly(named)
 
 	name, desc, err := remote.Resolve(ctx, named.String())
@@ -160,7 +167,7 @@ func DeleteDockerImage(ctx context.Context, named reference.Named, remote remote
 
 	var firstErr error
 	for _, host := range deleteHosts {
-		err := deleteDockerManifest(ctx, host, headers, refHost, repository, desc.Digest)
+		err := deleteRegistryManifest(ctx, host, headers, refHost, repository, desc.Digest)
 		if err == nil {
 			return nil
 		}
@@ -181,7 +188,7 @@ func filterHostsByCapability(hosts []docker.RegistryHost, cap docker.HostCapabil
 	return filtered
 }
 
-func deleteDockerManifest(ctx context.Context, host docker.RegistryHost, headers http.Header, refHost string, repository string, dgst digest.Digest) error {
+func deleteRegistryManifest(ctx context.Context, host docker.RegistryHost, headers http.Header, refHost string, repository string, dgst digest.Digest) error {
 	requestHeaders := http.Header{}
 	if headers != nil {
 		requestHeaders = headers.Clone()

--- a/image-spec/backend_test.go
+++ b/image-spec/backend_test.go
@@ -198,6 +198,92 @@ func TestBuildImageMultiPlatform(t *testing.T) {
 	}
 }
 
+func TestDeleteImage(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("tarball", func(t *testing.T) {
+		workDir := t.TempDir()
+		tarPath := filepath.Join(workDir, "image.tar")
+
+		// Save an image to a tarball
+		require.NoError(t, SaveTarball(ctx, tarPath, testImage))
+
+		// Verify the tarball exists
+		_, err := os.Stat(tarPath)
+		require.NoError(t, err)
+
+		// Delete the tarball
+		require.NoError(t, os.Remove(tarPath))
+
+		// Verify the tarball is deleted
+		_, err = os.Stat(tarPath)
+		require.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("oci-layout", func(t *testing.T) {
+		contentDir := t.TempDir()
+
+		// Save multiple images with different tags
+		_, err := SaveOCILayoutNamed(ctx, contentDir, "tag1", testImage)
+		require.NoError(t, err)
+		_, err = SaveOCILayoutNamed(ctx, contentDir, "tag2", testImage)
+		require.NoError(t, err)
+		_, err = SaveOCILayoutNamed(ctx, contentDir, "tag3", testImage)
+		require.NoError(t, err)
+
+		// Verify all tags exist in the index
+		indexPath := filepath.Join(contentDir, ocispec.ImageIndexFile)
+		indexData, err := os.ReadFile(indexPath)
+		require.NoError(t, err)
+		var index ocispec.Index
+		require.NoError(t, json.Unmarshal(indexData, &index))
+		require.Len(t, index.Manifests, 3)
+
+		// Helper to check tags in index
+		hasTag := func(index *ocispec.Index, tag string) bool {
+			for _, m := range index.Manifests {
+				if m.Annotations[ocispec.AnnotationRefName] == tag {
+					return true
+				}
+			}
+			return false
+		}
+
+		require.True(t, hasTag(&index, "tag1"))
+		require.True(t, hasTag(&index, "tag2"))
+		require.True(t, hasTag(&index, "tag3"))
+
+		// Delete tag2
+		require.NoError(t, DeleteOCILayoutNamed(contentDir, "tag2"))
+
+		// Verify tag2 is removed but tag1 and tag3 remain
+		indexData, err = os.ReadFile(indexPath)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(indexData, &index))
+		require.Len(t, index.Manifests, 2)
+		require.True(t, hasTag(&index, "tag1"))
+		require.False(t, hasTag(&index, "tag2"))
+		require.True(t, hasTag(&index, "tag3"))
+
+		// Delete tag1
+		require.NoError(t, DeleteOCILayoutNamed(contentDir, "tag1"))
+
+		// Verify only tag3 remains
+		indexData, err = os.ReadFile(indexPath)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(indexData, &index))
+		require.Len(t, index.Manifests, 1)
+		require.False(t, hasTag(&index, "tag1"))
+		require.False(t, hasTag(&index, "tag2"))
+		require.True(t, hasTag(&index, "tag3"))
+
+		// Delete non-existent tag should fail
+		err = DeleteOCILayoutNamed(contentDir, "nonexistent")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not found")
+	})
+}
+
 func requireTarPayload(t *testing.T, blob []byte, target string, expected []byte) {
 	t.Helper()
 

--- a/image-spec/go.mod
+++ b/image-spec/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/platforms v1.0.0-rc.2
 	github.com/distribution/reference v0.6.0
+	github.com/gofrs/flock v0.13.0
 	github.com/moby/buildkit v0.28.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -25,7 +26,6 @@ require (
 	github.com/getsentry/sentry-go v0.41.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/tools/imgtool/main.go
+++ b/tools/imgtool/main.go
@@ -27,6 +27,7 @@ import (
 type CLI struct {
 	Inspect InspectCmd `cmd:"" help:"Inspect an image"`
 	Copy    CopyCmd    `cmd:"" help:"Copy an image"`
+	Delete  DeleteCmd  `cmd:"" help:"Delete an image"`
 }
 
 type InspectCmd struct {
@@ -37,13 +38,12 @@ type InspectCmd struct {
 
 func (c *InspectCmd) Run(ctx context.Context) (rerr error) {
 	insecure := c.Insecure == "source" || c.Insecure == "all"
-
 	uri, err := imagespec.GuessURI(c.Image)
 	if err != nil {
 		return fmt.Errorf("parsing image reference: %w", err)
 	}
 
-	accessor := imagespec.NewAccessor(withResolver(insecure))
+	accessor := newAccessor(insecure)
 	imgs, err := accessor.LoadAll(ctx, uri, platforms.All)
 	if err != nil {
 		return err
@@ -163,7 +163,6 @@ type CopyCmd struct {
 
 func (c *CopyCmd) Run(ctx context.Context) (rerr error) {
 	insecure := c.Insecure == "source" || c.Insecure == "all"
-
 	src, err := imagespec.GuessURI(c.Source)
 	if err != nil {
 		return fmt.Errorf("parsing image source: %w", err)
@@ -173,7 +172,7 @@ func (c *CopyCmd) Run(ctx context.Context) (rerr error) {
 		return fmt.Errorf("parsing image destination: %w", err)
 	}
 
-	accessor := imagespec.NewAccessor(withResolver(insecure))
+	accessor := newAccessor(insecure)
 	imgs, err := accessor.LoadAll(ctx, src, platforms.All)
 	if err != nil {
 		return err
@@ -187,12 +186,32 @@ func (c *CopyCmd) Run(ctx context.Context) (rerr error) {
 	}()
 
 	insecure = c.Insecure == "destination" || c.Insecure == "all"
-	accessor = imagespec.NewAccessor(withResolver(insecure))
+	accessor = newAccessor(insecure)
 	err = accessor.Save(ctx, dest, imgs...)
 	if err != nil {
 		return fmt.Errorf("saving image to destination: %w", err)
 	}
 
+	return nil
+}
+
+type DeleteCmd struct {
+	Image string `arg:"" name:"image" help:"Image reference or path"`
+
+	Insecure string `help:"Allow insecure connections when accessing remote images" enum:"source,all,none" default:"none"`
+}
+
+func (c *DeleteCmd) Run(ctx context.Context) error {
+	insecure := c.Insecure == "source" || c.Insecure == "all"
+	uri, err := imagespec.GuessURI(c.Image)
+	if err != nil {
+		return fmt.Errorf("parsing image reference: %w", err)
+	}
+
+	accessor := newAccessor(insecure)
+	if err := accessor.Delete(ctx, uri); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/tools/imgtool/resolver.go
+++ b/tools/imgtool/resolver.go
@@ -15,7 +15,7 @@ import (
 	"unikraft.com/x/version"
 )
 
-func withResolver(insecure bool) imagespec.AccessOpt {
+func newAccessor(insecure bool) *imagespec.Accessor {
 	headers := http.Header{}
 	headers.Set("User-Agent", version.UserAgent())
 
@@ -41,5 +41,10 @@ func withResolver(insecure bool) imagespec.AccessOpt {
 		Headers: headers,
 		Hosts:   docker.ConfigureDefaultRegistries(opts...),
 	}
-	return imagespec.WithResolver(docker.NewResolver(dro))
+	resolver := docker.NewResolver(dro)
+	return imagespec.NewAccessor(
+		imagespec.WithResolver(resolver),
+		imagespec.WithRegistryHosts(dro.Hosts),
+		imagespec.WithRegistryHeaders(dro.Headers),
+	)
 }


### PR DESCRIPTION
We use the OCI image distribution protocol to allow deleting images, so as to free up a user's quota.

Fixes https://linear.app/unikraft/issue/TOOL-599/implement-unikraft-image-remove.