### PR TITLE
feat(kingkong): Render per-flag placeholders, examples and choices

### DIFF
--- a/kingkong/group.go
+++ b/kingkong/group.go
@@ -6,32 +6,36 @@
 package kingkong
 
 import (
-	"slices"
-
 	"github.com/alecthomas/kong"
 )
 
 const tagCollapse = "collapse"
 
+// Flag wraps kong.Flag and keeps collapsed flag variants.
+type Flag struct {
+	*kong.Flag
+	Collapsed []*kong.Flag
+}
+
 type FlagGroup struct {
 	Metadata *kong.Group
-	Flags    [][]*kong.Flag
+	Flags    [][]*Flag
 }
 
 func GroupFlags(flags [][]*kong.Flag) []FlagGroup {
 	// Group keys in order of appearance.
 	groups := []*kong.Group{}
 	// Flags grouped by their group key.
-	flagsByGroup := map[string][][]*kong.Flag{}
+	flagsByGroup := map[string][][]*Flag{}
 
 	for _, levelFlags := range flags {
-		levelFlags = collapseFlags(levelFlags)
+		collapsedFlags := collapseFlags(levelFlags)
 
-		levelFlagsByGroup := map[string][]*kong.Flag{}
+		levelFlagsByGroup := map[string][]*Flag{}
 
-		for _, flag := range levelFlags {
+		for _, flag := range collapsedFlags {
 			key := ""
-			if flag.Flag.Name == "help" && flag.Group == nil {
+			if flag.Name == "help" && flag.Group == nil {
 				flag.Group = &kong.Group{
 					Key: "flag-global",
 				}
@@ -53,8 +57,8 @@ func GroupFlags(flags [][]*kong.Flag) []FlagGroup {
 			levelFlagsByGroup[key] = append(levelFlagsByGroup[key], flag)
 		}
 
-		for key, flags := range levelFlagsByGroup {
-			flagsByGroup[key] = append(flagsByGroup[key], flags)
+		for key, groupedFlags := range levelFlagsByGroup {
+			flagsByGroup[key] = append(flagsByGroup[key], groupedFlags)
 		}
 	}
 
@@ -74,22 +78,22 @@ func GroupFlags(flags [][]*kong.Flag) []FlagGroup {
 	return out
 }
 
-func collapseFlags(flags []*kong.Flag) []*kong.Flag {
-	out := make([]*kong.Flag, 0, len(flags))
-	byID := map[string]*kong.Flag{}
+func collapseFlags(flags []*kong.Flag) []*Flag {
+	out := make([]*Flag, 0, len(flags))
+	byID := map[string]*Flag{}
 
 	for _, flag := range flags {
 		if flag == nil {
 			continue
 		}
 		if flag.Value == nil || flag.Tag == nil {
-			out = append(out, flag)
+			out = append(out, &Flag{Flag: flag})
 			continue
 		}
 
 		id := flag.Tag.Get(tagCollapse)
 		if id == "" {
-			out = append(out, flag)
+			out = append(out, &Flag{Flag: flag})
 			continue
 		}
 
@@ -98,25 +102,16 @@ func collapseFlags(flags []*kong.Flag) []*kong.Flag {
 			clone := new(kong.Flag)
 			*clone = *flag
 			clone.Aliases = append([]string(nil), flag.Aliases...)
-			byID[id] = clone
-			out = append(out, clone)
+			wrapped := &Flag{Flag: clone}
+			byID[id] = wrapped
+			out = append(out, wrapped)
 			continue
 		}
 
-		appendUniqueAlias(base, flag.Name)
+		base.Collapsed = append(base.Collapsed, flag)
 	}
 
 	return out
-}
-
-func appendUniqueAlias(flag *kong.Flag, name string) {
-	if flag == nil || name == "" || name == flag.Name {
-		return
-	}
-	if slices.Contains(flag.Aliases, name) {
-		return
-	}
-	flag.Aliases = append(flag.Aliases, name)
 }
 
 type CommandGroup struct {

--- a/kingkong/help.go
+++ b/kingkong/help.go
@@ -34,10 +34,11 @@ var (
 	Underline = lipgloss.NewStyle().Underline(true).Render
 	Bold      = lipgloss.NewStyle().Bold(true).Render
 
-	EnvVarColor     = lipgloss.NewStyle().Foreground(compat.AdaptiveColor{Light: colors.Emerald500, Dark: colors.Emerald200}).Render
-	CommandColor    = lipgloss.NewStyle().Foreground(compat.AdaptiveColor{Light: colors.Blue500, Dark: colors.Blue200}).Render
-	DimmedColor     = lipgloss.NewStyle().Foreground(compat.AdaptiveColor{Light: colors.Slate500, Dark: colors.Slate300}).Render
-	DimmedMoreColor = lipgloss.NewStyle().Foreground(compat.AdaptiveColor{Light: colors.Slate400, Dark: colors.Slate400}).Render
+	EnvVarColor      = lipgloss.NewStyle().Foreground(compat.AdaptiveColor{Light: colors.Emerald500, Dark: colors.Emerald200}).Render
+	CommandColor     = lipgloss.NewStyle().Foreground(compat.AdaptiveColor{Light: colors.Blue500, Dark: colors.Blue200}).Render
+	DimmedColor      = lipgloss.NewStyle().Foreground(compat.AdaptiveColor{Light: colors.Slate500, Dark: colors.Slate300}).Render
+	DimmedMoreColor  = lipgloss.NewStyle().Foreground(compat.AdaptiveColor{Light: colors.Slate400, Dark: colors.Slate400}).Render
+	PlaceholderColor = lipgloss.NewStyle().Foreground(compat.AdaptiveColor{Light: colors.Blue400, Dark: colors.Blue300}).Render
 )
 
 // HelpPrinter returns a function implementation of kong.HelpPrinter.
@@ -413,6 +414,8 @@ func (h *helpWriter) Wrap(text string) {
 	}
 }
 
+const tagExample = "example"
+
 // helpValueFormatter implements kong.HelpValueFormatter.
 func helpValueFormatter(value *kong.Value) string {
 	var buf strings.Builder
@@ -421,19 +424,82 @@ func helpValueFormatter(value *kong.Value) string {
 	buf.WriteString(DimmedColor(strings.TrimSuffix(value.Help, ".") + "."))
 	buf.WriteString("\n")
 
+	hasMetadata := false
+
 	if len(value.Default) > 0 {
 		buf.WriteString(DimmedColor("[default: ") + value.Default)
+		hasMetadata = true
 	}
 
 	if len(value.Tag.Enum) > 0 {
-		buf.WriteString(DimmedColor(", choice: ") + value.Tag.Enum)
+		if hasMetadata {
+			buf.WriteString(DimmedColor(", "))
+		} else {
+			buf.WriteString(DimmedColor("["))
+		}
+		choices := strings.Split(value.Tag.Enum, ",")
+		buf.WriteString(DimmedColor("choices: ") + strings.Join(choices, DimmedColor(", ")))
+		hasMetadata = true
 	}
 
-	if len(value.Default) > 0 || len(value.Tag.Enum) > 0 {
+	if examples := parseExamples(value.Tag.Get(tagExample)); len(examples) > 0 {
+		if hasMetadata {
+			buf.WriteString(DimmedColor(", "))
+		} else {
+			buf.WriteString(DimmedColor("["))
+		}
+		if len(examples) == 1 {
+			buf.WriteString(DimmedColor("example: ") + examples[0])
+		} else {
+			buf.WriteString(DimmedColor("examples: ") + strings.Join(examples, DimmedColor(", ")))
+		}
+		hasMetadata = true
+	}
+
+	if hasMetadata {
 		buf.WriteString(DimmedColor("]"))
 	}
 
 	return buf.String()
+}
+
+// parseExamples parses a comma-separated list of examples, supporting escaped commas.
+// Use \, to include a literal comma in an example.
+func parseExamples(s string) []string {
+	if s == "" {
+		return nil
+	}
+
+	var examples []string
+	var current strings.Builder
+	escaped := false
+
+	for _, r := range s {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			continue
+		}
+		if r == ',' {
+			if str := strings.TrimSpace(current.String()); str != "" {
+				examples = append(examples, str)
+			}
+			current.Reset()
+			continue
+		}
+		current.WriteRune(r)
+	}
+
+	// Don't forget the last segment.
+	if str := strings.TrimSpace(current.String()); str != "" {
+		examples = append(examples, str)
+	}
+
+	return examples
 }
 
 func writePositionals(w *helpWriter, args []*kong.Positional) {
@@ -444,7 +510,7 @@ func writePositionals(w *helpWriter, args []*kong.Positional) {
 	writeTwoColumns(w, rows)
 }
 
-func writeFlags(w *helpWriter, groups [][]*kong.Flag) {
+func writeFlags(w *helpWriter, groups [][]*Flag) {
 	rows := [][2]string{}
 	for i, group := range groups {
 		if i > 0 {
@@ -470,9 +536,8 @@ func writeTwoColumns(w *helpWriter, rows [][2]string) {
 }
 
 // formatFlag returns a formatted flag string, including short and long names,
-func formatFlag(flag *kong.Flag) string {
+func formatFlag(flag *Flag) string {
 	var buf strings.Builder
-	names := append([]string{flag.Name}, flag.Aliases...)
 	isBool := flag.IsBool()
 
 	short := "    "
@@ -480,16 +545,37 @@ func formatFlag(flag *kong.Flag) string {
 		short = "-" + string(flag.Short) + DimmedColor(", ")
 	}
 
-	for i := range names {
-		if isBool && flag.Tag.Negatable == NegatableDefault {
-			names[i] = "[no-]" + names[i]
-		} else if isBool && flag.Tag.Negatable != "" {
-			names[i] += "/" + flag.Tag.Negatable
+	formattedNames := make([]string, 0, 1+len(flag.Aliases)+len(flag.Collapsed))
+	appendNames := func(names []string, placeholder string) {
+		for i, name := range names {
+			formatted := "--" + name
+			if isBool {
+				if flag.Tag.Negatable == NegatableDefault {
+					formatted = "--[no-]" + name
+				} else if flag.Tag.Negatable != "" {
+					formatted = "--" + name + "/" + flag.Tag.Negatable
+				}
+			}
+
+			// Add placeholder if available.
+			if !isBool && i == 0 && placeholder != "" {
+				formatted += DimmedColor("=") + renderPlaceholder(placeholder)
+			}
+
+			formattedNames = append(formattedNames, formatted)
 		}
-		names[i] = "--" + names[i]
 	}
 
-	buf.WriteString(fmt.Sprintf("%s%s", short, strings.Join(names, ", ")))
+	appendNames(append([]string{flag.Name}, flag.Aliases...), flag.PlaceHolder)
+	for _, collapsed := range flag.Collapsed {
+		if collapsed == nil {
+			continue
+		}
+		appendNames(append([]string{collapsed.Name}, collapsed.Aliases...), collapsed.PlaceHolder)
+	}
+
+	buf.WriteString(short)
+	buf.WriteString(strings.Join(formattedNames, DimmedColor(", ")))
 
 	if len(flag.Tag.Envs) > 0 {
 		buf.WriteString(" ")
@@ -499,6 +585,41 @@ func formatFlag(flag *kong.Flag) string {
 	}
 
 	return buf.String()
+}
+
+func renderPlaceholder(placeholder string) string {
+	if !hasAnglePair(placeholder) {
+		return PlaceholderColor("<" + placeholder + ">")
+	}
+
+	var buf strings.Builder
+	rest := placeholder
+	for {
+		start := strings.Index(rest, "<")
+		if start == -1 {
+			buf.WriteString(rest)
+			break
+		}
+		end := strings.Index(rest[start+1:], ">")
+		if end == -1 {
+			buf.WriteString(rest)
+			break
+		}
+		end += start + 1
+		buf.WriteString(rest[:start])
+		buf.WriteString(PlaceholderColor(rest[start : end+1]))
+		rest = rest[end+1:]
+	}
+
+	return buf.String()
+}
+
+func hasAnglePair(placeholder string) bool {
+	_, rest, ok := strings.Cut(placeholder, "<")
+	if !ok {
+		return false
+	}
+	return strings.Contains(rest, ">")
 }
 
 func formatEnvs(envs []string) string {

--- a/kingkong/help_test.go
+++ b/kingkong/help_test.go
@@ -19,9 +19,11 @@ import (
 )
 
 type helpGoldenCLI struct {
-	Config  string `help:"Path to config file." default:"./kingkong.yaml" env:"KINGKONG_CONFIG" placeholder:"FILE" group:"core"`
+	Config  string `help:"Path to config file." default:"./kingkong.yaml" env:"KINGKONG_CONFIG" group:"core"`
 	Profile string `help:"Runtime profile." enum:"dev,staging,prod" default:"dev" group:"core"`
 	Output  string `help:"Output format." enum:"json,yaml,text" default:"json" group:"core"`
+	Value   string `help:"Value to apply." placeholder:"<value>" group:"core"`
+	Filter  string `help:"Filter in key-value form." placeholder:"<key>=<value>" group:"core"`
 	Verbose bool   `help:"Enable verbose logging." short:"v" group:"core"`
 	Debug   bool   `help:"Enable debug logging." negatable:"" env:"KINGKONG_DEBUG" group:"core"`
 
@@ -111,6 +113,30 @@ func TestHelpGolden(t *testing.T) {
 	normalized := normalizeHelpOutput(output)
 
 	golden.Assert(t, normalized, "help.golden")
+}
+
+func TestCollapsedFlagPlaceholders(t *testing.T) {
+	type collapseCLI struct {
+		Foo string `help:"Foo value." placeholder:"<value>" collapse:"pair"`
+		Bar string `help:"Bar filter." placeholder:"<key>=<value>" collapse:"pair" aliases:"baz"`
+	}
+
+	var cli collapseCLI
+	app, err := kong.New(&cli)
+	require.NoError(t, err)
+
+	flags := collapseFlags(app.Model.Flags)
+	var collapsed *Flag
+	for _, flag := range flags {
+		if flag.Name == "foo" {
+			collapsed = flag
+			break
+		}
+	}
+	require.NotNil(t, collapsed)
+
+	formatted := strings.TrimSpace(ansi.Strip(formatFlag(collapsed)))
+	require.Equal(t, "--foo=<value>, --bar=<key>=<value>, --baz", formatted)
 }
 
 func captureHelpOutput(t *testing.T, app *kong.Kong, buf *bytes.Buffer) (output string) {

--- a/kingkong/testdata/help.golden
+++ b/kingkong/testdata/help.golden
@@ -17,10 +17,14 @@ Core Flags
           [default: ./kingkong.yaml]
       --profile
           Runtime profile.
-          [default: dev, choice: dev,staging,prod]
+          [default: dev, choices: dev, staging, prod]
       --output
           Output format.
-          [default: json, choice: json,yaml,text]
+          [default: json, choices: json, yaml, text]
+      --value=<value>
+          Value to apply.
+      --filter=<key>=<value>
+          Filter in key-value form.
   -v, --verbose
           Enable verbose logging.
       --[no-]debug ($KINGKONG_DEBUG)


### PR DESCRIPTION
Per-flag we can have:
- Placeholders. These were defined in kong, but we weren't rendering.
- Choices. These felt cramped, so I spaced them out.
- Examples. It's nice to have inline examples of what you can pass.

I also had to refactor some of the collapsing, since this was causing weird issues with the placeholders as well.

This is what this might look like in https://github.com/unikraft/cli:

<img width="520" height="801" alt="image" src="https://github.com/user-attachments/assets/6c633def-1c96-404e-96ab-5576ba0fb6a4" />