### PR TITLE
feat(tools/protoc-gen-go-struct): Add option to omit path params

### DIFF
--- a/tools/protoc-gen-go-struct/go.mod
+++ b/tools/protoc-gen-go-struct/go.mod
@@ -5,6 +5,7 @@ go 1.25.5
 require (
 	github.com/iancoleman/strcase v0.3.0
 	golang.org/x/tools v0.43.0
+	google.golang.org/genproto/googleapis/api v0.0.0-20260316180232-0b37fe3546d5
 	google.golang.org/protobuf v1.36.11
 )
 

--- a/tools/protoc-gen-go-struct/go.sum
+++ b/tools/protoc-gen-go-struct/go.sum
@@ -8,5 +8,7 @@ golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
 golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
+google.golang.org/genproto/googleapis/api v0.0.0-20260316180232-0b37fe3546d5 h1:CogIeEXn4qWYzzQU0QqvYBM8yDF9cFYzDq9ojSpv0Js=
+google.golang.org/genproto/googleapis/api v0.0.0-20260316180232-0b37fe3546d5/go.mod h1:EIQZ5bFCfRQDV4MhRle7+OgjNtZ6P1PiZBgAKuxXu/Y=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/tools/protoc-gen-go-struct/main.go
+++ b/tools/protoc-gen-go-struct/main.go
@@ -16,21 +16,25 @@ import (
 	"text/template"
 
 	"github.com/iancoleman/strcase"
+	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 const pluginName = "unikraft.com/x/tools/protoc-gen-go-struct"
 
 type TemplateData struct {
-	PluginName  string
-	BasePackage string
-	NativeTime  bool
-	Version     string
-	Package     string
-	Imports     map[string]string // package alias -> import path
-	Structs     map[string]Struct
-	Enums       []Enum
+	PluginName      string
+	BasePackage     string
+	NativeTime      bool
+	OmitPathParams  bool
+	Version         string
+	Package         string
+	Imports         map[string]string // package alias -> import path
+	Structs         map[string]Struct
+	Enums           []Enum
+	PathParamFields map[string]map[string]bool // message name -> field names to omit
 }
 
 type Struct struct {
@@ -65,6 +69,7 @@ func main() {
 	var flags flag.FlagSet
 	basePackage := flags.String("base_package", "", "Base package to prefix imports")
 	nativeTime := flags.Bool("native_time", false, "Use time.Time instead of timestamppb.Timestamp")
+	omitPathParams := flags.Bool("omit_path_params", false, "Omit fields from input messages that are used as path parameters in HTTP methods")
 
 	protogen.Options{
 		ParamFunc: flags.Set,
@@ -74,7 +79,7 @@ func main() {
 				continue
 			}
 
-			err := generateFile(plugin, file, *basePackage, *nativeTime)
+			err := generateFile(plugin, file, *basePackage, *nativeTime, *omitPathParams)
 			if err != nil {
 				return err
 			}
@@ -84,14 +89,22 @@ func main() {
 	})
 }
 
-func generateFile(plugin *protogen.Plugin, file *protogen.File, basePackage string, nativeTime bool) error {
+func generateFile(plugin *protogen.Plugin, file *protogen.File, basePackage string, nativeTime bool, omitPathParams bool) error {
 	templateData := &TemplateData{
-		PluginName:  pluginName,
-		BasePackage: basePackage,
-		NativeTime:  nativeTime,
-		Package:     string(file.GoPackageName),
-		Imports:     make(map[string]string),
+		PluginName:      pluginName,
+		BasePackage:     basePackage,
+		NativeTime:      nativeTime,
+		OmitPathParams:  omitPathParams,
+		Package:         string(file.GoPackageName),
+		Imports:         make(map[string]string),
+		PathParamFields: make(map[string]map[string]bool),
 	}
+
+	// If omitPathParams is enabled, extract path parameters from HTTP annotations
+	if omitPathParams {
+		templateData.PathParamFields = extractPathParamFields(file.Services)
+	}
+
 	templateData.Structs = templateData.getStructs(file.Messages...)
 	templateData.Enums = templateData.getEnums(file.Enums)
 
@@ -113,6 +126,66 @@ func generateFile(plugin *protogen.Plugin, file *protogen.File, basePackage stri
 	}
 
 	return nil
+}
+
+// extractPathParamFields extracts path parameters from HTTP annotations on service methods
+// and returns a map of message name -> set of field names that should be omitted.
+func extractPathParamFields(services []*protogen.Service) map[string]map[string]bool {
+	result := make(map[string]map[string]bool)
+
+	for _, service := range services {
+		for _, method := range service.Methods {
+			rule, ok := proto.GetExtension(method.Desc.Options(), annotations.E_Http).(*annotations.HttpRule)
+			if rule == nil || !ok {
+				continue
+			}
+
+			var uri string
+			if u := rule.GetGet(); u != "" {
+				uri = u
+			} else if u := rule.GetPost(); u != "" {
+				uri = u
+			} else if u := rule.GetPut(); u != "" {
+				uri = u
+			} else if u := rule.GetPatch(); u != "" {
+				uri = u
+			} else if u := rule.GetDelete(); u != "" {
+				uri = u
+			}
+
+			if uri == "" {
+				continue
+			}
+
+			// Extract path parameters from URI (e.g., {name} or :name)
+			var pathParams []string
+			for p := range strings.SplitSeq(uri, "/") {
+				if len(p) > 0 && (p[0] == '{' && p[len(p)-1] == '}') {
+					pathParams = append(pathParams, p[1:len(p)-1])
+				} else if len(p) > 0 && p[0] == ':' {
+					pathParams = append(pathParams, p[1:])
+				}
+			}
+
+			if len(pathParams) == 0 {
+				continue
+			}
+
+			// Map path params to message fields
+			inputMsg := method.Input.GoIdent.GoName
+			if result[inputMsg] == nil {
+				result[inputMsg] = make(map[string]bool)
+			}
+
+			for _, param := range pathParams {
+				// Convert path param to Go field name (CamelCase)
+				fieldName := strcase.ToCamel(param)
+				result[inputMsg][fieldName] = true
+			}
+		}
+	}
+
+	return result
 }
 
 // generatePackageAlias creates a package alias from a proto file path
@@ -159,6 +232,15 @@ func (td *TemplateData) getStructs(messages ...*protogen.Message) map[string]Str
 		}
 
 		for _, field := range m.Fields {
+			// Skip fields that are path parameters if omitPathParams is enabled
+			if td.OmitPathParams {
+				if fieldsToOmit, ok := td.PathParamFields[m.GoIdent.GoName]; ok {
+					if fieldsToOmit[field.GoName] {
+						continue
+					}
+				}
+			}
+
 			f := StructField{
 				Name:    field.GoName,
 				Comment: field.Comments.Leading.String(),


### PR DESCRIPTION
Add `--omit_path_params` flag that removes fields from generated structs when those fields are used as path parameters in HTTP method annotations.

This prevents field duplication when a field appears both in the request body and as a path parameter (e.g., {name} in the URI).
