### PR TITLE
feat(tools/protoc-gen-go-gin)!: Body & query field rework

### DIFF
--- a/tools/protoc-gen-go-gin/gin.tmpl
+++ b/tools/protoc-gen-go-gin/gin.tmpl
@@ -14,6 +14,9 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"unikraft.com/x/log"
+{{- range $path, $alias := .ExtraImports }}
+	{{ $alias }} "{{ $path }}"
+{{- end }}
 )
 
 // Prevent import errors.
@@ -40,9 +43,10 @@ type {{ $service.Name }} interface {
 	{{- if ne $method.Comment "" }}
 	{{- $method.Comment }}
 	{{- end -}}
-	{{- $hasReq := ne $method.Input.Desc.FullName "google.protobuf.Empty" -}}
 	{{- $hasRes := ne $method.Output.Desc.FullName "google.protobuf.Empty" -}}
 	{{- $resAsAny := eq $method.Output.Desc.FullName "google.protobuf.Any" -}}
+	{{- $hasBodyField := ne $method.BodyFieldName "" -}}
+	{{- $hasQueryFields := gt (len $method.QueryFields) 0 -}}
 	{{ $method.Name }}(g *gin.Context
 	{{- if $method.IsStreamingServer -}}
 	, cancel context.CancelFunc
@@ -50,9 +54,24 @@ type {{ $service.Name }} interface {
 	{{- range $method.PathParams -}}
 	, {{ . }} string
 	{{- end -}}
-	{{- if $hasReq -}}
-	, req *{{ $method.Input.GoIdent.GoName -}}
-	{{ end -}}
+	{{- if $method.BodyIsFullMessage -}}
+	{{- /* body: "*" means entire message is the body */ -}}
+	, req *{{ $method.Input.GoIdent.GoName }}
+	{{- else if $hasBodyField -}}
+	{{- /* When body field is specified, use body field type directly */ -}}
+	{{- if $method.BodyField.Desc.IsList }}, body []{{ if $method.BodyField.Message }}*{{ end }}{{ goType $method.BodyField }}
+	{{- else if $method.BodyField.Message }}, body *{{ goType $method.BodyField }}
+	{{- else }}, body {{ goType $method.BodyField }}{{ end }}
+	{{- end -}}
+	{{- /* Add query parameters as separate arguments */ -}}
+	{{- if $hasQueryFields -}}
+	{{- range $method.QueryFields -}}
+	{{- if .Desc.IsList }}, {{ .GoName | toLowerCamel }} []{{ if .Message }}*{{ end }}{{ goType . }}
+	{{- else if .Message }}, {{ .GoName | toLowerCamel }} *{{ goType . }}
+	{{- else if .Desc.HasOptionalKeyword }}, {{ .GoName | toLowerCamel }} *{{ goType . }}
+	{{- else }}, {{ .GoName | toLowerCamel }} {{ goType . }}{{ end }}
+	{{- end -}}
+	{{- end -}}
 	) (
 	{{- if $method.IsStreamingServer -}}
 	<-chan *{{ .Output.GoIdent.GoName }}
@@ -83,6 +102,8 @@ func Register{{$service.Name}}(engine *gin.Engine, service {{ $service.Name }}, 
 
 {{ range .Methods }}
 {{ $method := . }}
+{{- $hasBodyField := ne $method.BodyFieldName "" }}
+{{- $hasQueryFields := gt (len $method.QueryFields) 0 }}
 func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *gin.Context) {
 	{{ if gt (len $method.PathParams) 0 }}
 	var params struct {
@@ -104,7 +125,8 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 	}
 
 	{{ end -}}
-	{{- if ne $method.Input.Desc.FullName "google.protobuf.Empty" -}}
+	{{- if $method.BodyIsFullMessage -}}
+	{{- /* body: "*" - bind entire message as body */ -}}
 	bodyBytes, err := g.GetRawData()
 	if err != nil {
 		log.G(g.Request.Context()).
@@ -122,8 +144,8 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 	// Restore the body for further use.
 	g.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
-	var in {{ $method.Input.GoIdent.GoName }}
-	if err := g.ShouldBind(&in); err != nil {
+	var req {{ $method.Input.GoIdent.GoName }}
+	if err := g.ShouldBind(&req); err != nil {
 		log.G(g.Request.Context()).
 			Warn().
 			Err(err).
@@ -138,6 +160,107 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 
 	// Restore the body for further use.
 	g.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	{{ else if $hasBodyField -}}
+	{{- /* Body field is specified, bind body to its type and query params separately */ -}}
+	bodyBytes, err := g.GetRawData()
+	if err != nil {
+		log.G(g.Request.Context()).
+			Warn().
+			Err(err).
+			Msg("failed to read request body")
+		if handler.resp != nil {
+			handler.resp(g, http.StatusBadRequest, err)
+		} else {
+			g.JSON(http.StatusBadRequest, err)
+		}
+		return
+	}
+
+	// Restore the body for further use.
+	g.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	// Bind the body field directly
+	{{- if $method.BodyField.Desc.IsList }}
+	var body []{{ if $method.BodyField.Message }}*{{ end }}{{ goType $method.BodyField }}
+	{{- else if $method.BodyField.Message }}
+	var body {{ goType $method.BodyField }}
+	{{- else }}
+	var body {{ goType $method.BodyField }}
+	{{- end }}
+	if err := json.NewDecoder(g.Request.Body).Decode(&body); err != nil && err != io.EOF {
+		log.G(g.Request.Context()).
+			Warn().
+			Err(err).
+			Msg("failed to bind request body")
+		if handler.resp != nil {
+			handler.resp(g, http.StatusBadRequest, err)
+		} else {
+			g.JSON(http.StatusBadRequest, err)
+		}
+		return
+	}
+
+	// Restore the body for further use.
+	g.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	{{- if $hasQueryFields }}
+	// Bind query parameters
+	var query struct {
+		{{- range $method.QueryFields }}
+		{{- if .Desc.IsList }}
+		{{ .GoName }} []{{ if .Message }}*{{ end }}{{ goType . }} `form:"{{ .Desc.JSONName }}"`
+		{{- else if .Message }}
+		{{ .GoName }} *{{ goType . }} `form:"{{ .Desc.JSONName }}"`
+		{{- else if .Desc.HasOptionalKeyword }}
+		{{ .GoName }} *{{ goType . }} `form:"{{ .Desc.JSONName }}"`
+		{{- else }}
+		{{ .GoName }} {{ goType . }} `form:"{{ .Desc.JSONName }}"`
+		{{- end }}
+		{{- end }}
+	}
+	if err := g.ShouldBindQuery(&query); err != nil {
+		log.G(g.Request.Context()).
+			Warn().
+			Err(err).
+			Msg("failed to bind query parameters")
+		if handler.resp != nil {
+			handler.resp(g, http.StatusBadRequest, err)
+		} else {
+			g.JSON(http.StatusBadRequest, err)
+		}
+		return
+	}
+	{{- end }}
+
+	{{ else if $hasQueryFields -}}
+	{{- /* No body field, bind all non-path fields as query parameters */ -}}
+	// Bind query parameters
+	var query struct {
+		{{- range $method.QueryFields }}
+		{{- if .Desc.IsList }}
+		{{ .GoName }} []{{ if .Message }}*{{ end }}{{ goType . }} `form:"{{ .Desc.JSONName }}"`
+		{{- else if .Message }}
+		{{ .GoName }} *{{ goType . }} `form:"{{ .Desc.JSONName }}"`
+		{{- else if .Desc.HasOptionalKeyword }}
+		{{ .GoName }} *{{ goType . }} `form:"{{ .Desc.JSONName }}"`
+		{{- else }}
+		{{ .GoName }} {{ goType . }} `form:"{{ .Desc.JSONName }}"`
+		{{- end }}
+		{{- end }}
+	}
+	if err := g.ShouldBindQuery(&query); err != nil {
+		log.G(g.Request.Context()).
+			Warn().
+			Err(err).
+			Msg("failed to bind query parameters")
+		if handler.resp != nil {
+			handler.resp(g, http.StatusBadRequest, err)
+		} else {
+			g.JSON(http.StatusBadRequest, err)
+		}
+		return
+	}
 
 	{{ end -}}
 	{{- if $method.IsStreamingServer }}
@@ -171,8 +294,15 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 	params.{{ . | toCamel }},
 	{{ end }}
 	{{ end }}
-	{{- if ne $method.Input.Desc.FullName "google.protobuf.Empty" -}}
-	&in
+	{{- if $method.BodyIsFullMessage -}}
+	&req,
+	{{- else if $hasBodyField -}}
+	body,
+	{{- end }}
+	{{- if $hasQueryFields -}}
+	{{- range $method.QueryFields }}
+	query.{{ .GoName }},
+	{{- end }}
 	{{- end -}}
 	)
 
@@ -244,8 +374,15 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 	params.{{ . | toCamel }},
 	{{- end }}
 	{{- end }}
-	{{- if ne $method.Input.Desc.FullName "google.protobuf.Empty" -}}
-	&in
+	{{- if $method.BodyIsFullMessage -}}
+	&req,
+	{{- else if $hasBodyField -}}
+	body,
+	{{- end }}
+	{{- if $hasQueryFields -}}
+	{{- range $method.QueryFields }}
+	query.{{ .GoName }},
+	{{- end }}
 	{{- end -}}
 	)
 	if err != nil {

--- a/tools/protoc-gen-go-gin/main.go
+++ b/tools/protoc-gen-go-gin/main.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 const pluginName = "unikraft.com/x/tools/protoc-gen-go-gin"
@@ -24,9 +25,11 @@ const pluginName = "unikraft.com/x/tools/protoc-gen-go-gin"
 type TemplateData struct {
 	PluginName       string
 	Package          string
+	GoImportPath     protogen.GoImportPath
 	Services         []Service
 	StreamKeepalive  bool
 	StreamDataPrefix string
+	ExtraImports     map[string]string // import path -> alias
 }
 
 type Service struct {
@@ -53,10 +56,73 @@ type Method struct {
 //go:embed gin.tmpl
 var ginTmpl string
 
+// goTypeForField returns the Go type string for a protogen field, qualified with package alias if needed.
+func goTypeForField(f *protogen.Field, currentPkg protogen.GoImportPath, imports map[string]string, basePackage string) string {
+	if f.Message != nil {
+		return qualifiedGoType(f.Message.GoIdent, currentPkg, imports, basePackage)
+	}
+	if f.Enum != nil {
+		return qualifiedGoType(f.Enum.GoIdent, currentPkg, imports, basePackage)
+	}
+	// Map scalar protobuf kinds to Go types
+	switch f.Desc.Kind() {
+	case protoreflect.BoolKind:
+		return "bool"
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		return "int32"
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		return "uint32"
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		return "int64"
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return "uint64"
+	case protoreflect.FloatKind:
+		return "float32"
+	case protoreflect.DoubleKind:
+		return "float64"
+	case protoreflect.StringKind:
+		return "string"
+	case protoreflect.BytesKind:
+		return "[]byte"
+	default:
+		return "any"
+	}
+}
+
+// qualifiedGoType returns the Go type qualified with package alias if it's from a different package.
+func qualifiedGoType(ident protogen.GoIdent, currentPkg protogen.GoImportPath, imports map[string]string, basePackage string) string {
+	if ident.GoImportPath == currentPkg {
+		return ident.GoName
+	}
+	// Need to use qualified name
+	importPath := string(ident.GoImportPath)
+	if basePackage != "" && !strings.HasPrefix(importPath, basePackage) {
+		importPath = strings.TrimSuffix(basePackage, "/") + "/" + strings.TrimPrefix(importPath, "/")
+	}
+	alias := derivePackageAlias(importPath)
+	imports[importPath] = alias
+	return alias + "." + ident.GoName
+}
+
+// derivePackageAlias derives a short package alias from an import path.
+func derivePackageAlias(importPath string) string {
+	parts := strings.Split(importPath, "/")
+	if len(parts) == 0 {
+		return "pkg"
+	}
+	lastPart := parts[len(parts)-1]
+	// If the last part looks like a version (v1, v2, etc.), combine with previous part
+	if len(parts) > 1 && len(lastPart) >= 2 && lastPart[0] == 'v' && lastPart[1] >= '0' && lastPart[1] <= '9' {
+		return parts[len(parts)-2] + lastPart
+	}
+	return lastPart
+}
+
 func main() {
 	var flags flag.FlagSet
 	streamKeepalive := flags.Bool("stream_keepalive", true, "Send a regular keep-alive with a timestamp in streaming responses")
 	streamDataPrefix := flags.String("stream_data_prefix", "data", "Set a prefix for data messages in streaming responses")
+	basePackage := flags.String("base_package", "", "Base package to prepend to Go import paths")
 
 	protogen.Options{
 		ParamFunc: flags.Set,
@@ -65,7 +131,7 @@ func main() {
 			if !file.Generate {
 				continue
 			}
-			if err := generateFile(plugin, file, *streamKeepalive, *streamDataPrefix); err != nil {
+			if err := generateFile(plugin, file, *streamKeepalive, *streamDataPrefix, *basePackage); err != nil {
 				return err
 			}
 		}
@@ -74,7 +140,7 @@ func main() {
 	})
 }
 
-func generateFile(plugin *protogen.Plugin, file *protogen.File, streamKeepalive bool, streamDataPrefix string) error {
+func generateFile(plugin *protogen.Plugin, file *protogen.File, streamKeepalive bool, streamDataPrefix string, basePackage string) error {
 	services := getHTTPServices(file.Services)
 
 	// No service has http option.
@@ -82,12 +148,36 @@ func generateFile(plugin *protogen.Plugin, file *protogen.File, streamKeepalive 
 		return nil
 	}
 
+	// Track extra imports needed for body/query field types from other packages
+	extraImports := make(map[string]string)
+	currentPkg := file.GoImportPath
+
+	// goType is a closure that returns qualified types and tracks imports
+	goType := func(f *protogen.Field) string {
+		return goTypeForField(f, currentPkg, extraImports, basePackage)
+	}
+
+	// Pre-collect imports by iterating over all body and query fields.
+	// This ensures imports are available before template rendering.
+	for _, service := range services {
+		for _, method := range service.Methods {
+			if method.BodyField != nil {
+				goType(method.BodyField)
+			}
+			for _, qf := range method.QueryFields {
+				goType(qf)
+			}
+		}
+	}
+
 	templateData := TemplateData{
 		PluginName:       pluginName,
 		Package:          string(file.GoPackageName),
+		GoImportPath:     file.GoImportPath,
 		Services:         services,
 		StreamKeepalive:  streamKeepalive,
 		StreamDataPrefix: streamDataPrefix,
+		ExtraImports:     extraImports,
 	}
 
 	tmpl, err := template.
@@ -95,6 +185,7 @@ func generateFile(plugin *protogen.Plugin, file *protogen.File, streamKeepalive 
 		Funcs(template.FuncMap{
 			"toCamel":      strcase.ToCamel,
 			"toLowerCamel": strcase.ToLowerCamel,
+			"goType":       goType,
 		}).
 		Parse(ginTmpl)
 	if err != nil {

--- a/tools/protoc-gen-go-gin/main.go
+++ b/tools/protoc-gen-go-gin/main.go
@@ -44,6 +44,10 @@ type Method struct {
 	Output            *protogen.Message
 	PathParams        []string
 	IsStreamingServer bool
+	BodyFieldName     string            // Name of the field that maps to the HTTP body (from google.api.http body option)
+	BodyField         *protogen.Field   // The field that maps to the HTTP body
+	BodyIsFullMessage bool              // True when body: "*" - entire message is the body
+	QueryFields       []*protogen.Field // Fields that should be bound as query parameters
 }
 
 //go:embed gin.tmpl
@@ -167,6 +171,47 @@ func getHTTPServices(ps []*protogen.Service) []Service {
 					}
 				}
 				m.URI = strings.Join(paths, "/")
+
+				// Handle body field mapping from google.api.http body option
+				bodyFieldName := rule.GetBody()
+				if bodyFieldName == "*" {
+					// body: "*" means the entire message is the body
+					m.BodyIsFullMessage = true
+				} else if bodyFieldName != "" {
+					m.BodyFieldName = bodyFieldName
+					// Find the body field in the input message
+					for _, field := range method.Input.Fields {
+						if field.Desc.JSONName() == bodyFieldName || string(field.Desc.Name()) == bodyFieldName {
+							m.BodyField = field
+							break
+						}
+					}
+				}
+
+				// Collect fields as query parameters (excluding the body field and path params)
+				// Skip if body: "*" since the entire message is the body
+				if !m.BodyIsFullMessage {
+					for _, field := range method.Input.Fields {
+						fieldName := field.Desc.JSONName()
+						protoName := string(field.Desc.Name())
+						// Skip if this is the body field
+						if bodyFieldName != "" && (fieldName == bodyFieldName || protoName == bodyFieldName) {
+							continue
+						}
+						// Skip if this is a path parameter
+						isPathParam := false
+						for _, pp := range m.PathParams {
+							if fieldName == pp || protoName == pp {
+								isPathParam = true
+								break
+							}
+						}
+						if !isPathParam {
+							m.QueryFields = append(m.QueryFields, field)
+						}
+					}
+				}
+
 				sd.Methods = append(sd.Methods, m)
 			}
 		}


### PR DESCRIPTION
## Summary

Enhances the `protoc-gen-go-gin` code generator to properly handle body and query field specifications from `google.api.http` annotations, enabling more precise HTTP request binding in generated Gin handlers.

## Changes

### Method struct enhancements
- Added `BodyFieldName`, `BodyField`, `BodyIsFullMessage`, and `QueryFields` to track HTTP binding details
- Parse the `body` option from `google.api.http` annotations to determine which field (or full message) should be bound from the request body
- Collect remaining non-path fields as query parameters for automatic binding

### Cross-package type support
- Added helper functions (`goTypeForField`, `qualifiedGoType`, `derivePackageAlias`) to resolve Go types for fields, including types from external packages
- Added `base_package` CLI flag to determine when imports are needed
- Extended `TemplateData` with `GoImportPath` and `ExtraImports` for proper import management
- Registered `goType` template function for use in code generation

### Template updates
- Render extra imports when handler methods reference types from other packages
- Updated interface method signatures to include body and query parameters
- Updated handler implementations with proper binding logic for body fields vs query parameters

## Motivation

Previously, the generator treated all request fields uniformly without respecting the `body` field specification in HTTP annotations. This caused issues when APIs needed to distinguish between:
- Fields that should be parsed from the URL path
- Fields that should be parsed from the request body (JSON)
- Fields that should be parsed from query parameters

This change ensures generated code correctly binds request data according to the API definition.
