### PR TITLE
docs: Add LICENSE.md to all Go modules

### DIFF
--- a/colors/LICENSE.md
+++ b/colors/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/fingerprint/LICENSE.md
+++ b/fingerprint/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/guesstermwidth/LICENSE.md
+++ b/guesstermwidth/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/iata/LICENSE.md
+++ b/iata/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/image-spec/LICENSE.md
+++ b/image-spec/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/joinerrgroup/LICENSE.md
+++ b/joinerrgroup/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/kingkong/LICENSE.md
+++ b/kingkong/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/kraftfile/LICENSE.md
+++ b/kraftfile/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/limiter/LICENSE.md
+++ b/limiter/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/log/LICENSE.md
+++ b/log/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/middleware/LICENSE.md
+++ b/middleware/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/oidext/LICENSE.md
+++ b/oidext/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/ptr/LICENSE.md
+++ b/ptr/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/ringbuffer/LICENSE.md
+++ b/ringbuffer/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/router/LICENSE.md
+++ b/router/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/startstopper/LICENSE.md
+++ b/startstopper/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/text/LICENSE.md
+++ b/text/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/tools/LICENSE.md
+++ b/tools/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/version/LICENSE.md
+++ b/version/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md


### PR DESCRIPTION
This is a symbolic link; and will fix Godoc on pkg.go.dev.

Signed-off-by: Alexander Jung <alex@unikraft.com>
