### PR TITLE
fix(tools): Nested naming and imports

### DIFF
--- a/tools/protoc-gen-go-gin/gin.tmpl
+++ b/tools/protoc-gen-go-gin/gin.tmpl
@@ -297,7 +297,7 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 	{{- if $method.BodyIsFullMessage -}}
 	&req,
 	{{- else if $hasBodyField -}}
-	{{ if $method.BodyField.Message }}&{{ end }}body,
+	{{ if and $method.BodyField.Message (not $method.BodyField.Desc.IsList) }}&{{ end }}body,
 	{{- end }}
 	{{- if $hasQueryFields -}}
 	{{- range $method.QueryFields }}
@@ -377,7 +377,7 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 	{{- if $method.BodyIsFullMessage -}}
 	&req,
 	{{- else if $hasBodyField -}}
-	{{ if $method.BodyField.Message }}&{{ end }}body,
+	{{ if and $method.BodyField.Message (not $method.BodyField.Desc.IsList) }}&{{ end }}body,
 	{{- end }}
 	{{- if $hasQueryFields -}}
 	{{- range $method.QueryFields }}

--- a/tools/protoc-gen-go-gin/gin.tmpl
+++ b/tools/protoc-gen-go-gin/gin.tmpl
@@ -297,7 +297,7 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 	{{- if $method.BodyIsFullMessage -}}
 	&req,
 	{{- else if $hasBodyField -}}
-	body,
+	{{ if $method.BodyField.Message }}&{{ end }}body,
 	{{- end }}
 	{{- if $hasQueryFields -}}
 	{{- range $method.QueryFields }}
@@ -377,7 +377,7 @@ func (handler *{{ $service.Name }}Handler) {{ $method.Name | toLowerCamel }}(g *
 	{{- if $method.BodyIsFullMessage -}}
 	&req,
 	{{- else if $hasBodyField -}}
-	body,
+	{{ if $method.BodyField.Message }}&{{ end }}body,
 	{{- end }}
 	{{- if $hasQueryFields -}}
 	{{- range $method.QueryFields }}

--- a/tools/protoc-gen-go-gin/main.go
+++ b/tools/protoc-gen-go-gin/main.go
@@ -91,8 +91,9 @@ func goTypeForField(f *protogen.Field, currentPkg protogen.GoImportPath, imports
 
 // qualifiedGoType returns the Go type qualified with package alias if it's from a different package.
 func qualifiedGoType(ident protogen.GoIdent, currentPkg protogen.GoImportPath, imports map[string]string, basePackage string) string {
+	name := flattenGoName(ident.GoName)
 	if ident.GoImportPath == currentPkg {
-		return ident.GoName
+		return name
 	}
 	// Need to use qualified name
 	importPath := string(ident.GoImportPath)
@@ -101,7 +102,15 @@ func qualifiedGoType(ident protogen.GoIdent, currentPkg protogen.GoImportPath, i
 	}
 	alias := derivePackageAlias(importPath)
 	imports[importPath] = alias
-	return alias + "." + ident.GoName
+	return alias + "." + name
+}
+
+// flattenGoName removes underscores from protobuf nested type names to match
+// the struct generator's flattened naming convention.  Protobuf uses
+// "Parent_Child" for nested messages, but the struct generator defines them as
+// "ParentChild".  Top-level names (no underscore) are returned unchanged.
+func flattenGoName(name string) string {
+	return strings.ReplaceAll(name, "_", "")
 }
 
 // derivePackageAlias derives a short package alias from an import path.
@@ -157,14 +166,19 @@ func generateFile(plugin *protogen.Plugin, file *protogen.File, streamKeepalive 
 		return goTypeForField(f, currentPkg, extraImports, basePackage)
 	}
 
-	// Pre-collect imports by iterating over all body and query fields.
-	// This ensures imports are available before template rendering.
-	for _, service := range services {
-		for _, method := range service.Methods {
-			if method.BodyField != nil {
-				goType(method.BodyField)
+	// Pre-process: flatten GoIdent names and collect imports.
+	// Protobuf uses "Parent_Child" for nested messages, but the struct
+	// generator emits "ParentChild".  Flattening up-front means the
+	// template never needs to call flattenGoName.
+	for i := range services {
+		for j := range services[i].Methods {
+			m := &services[i].Methods[j]
+			m.Input.GoIdent.GoName = flattenGoName(m.Input.GoIdent.GoName)
+			m.Output.GoIdent.GoName = flattenGoName(m.Output.GoIdent.GoName)
+			if m.BodyField != nil {
+				goType(m.BodyField)
 			}
-			for _, qf := range method.QueryFields {
+			for _, qf := range m.QueryFields {
 				goType(qf)
 			}
 		}

--- a/tools/protoc-gen-go-gin/main_test.go
+++ b/tools/protoc-gen-go-gin/main_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package main
+
+import "testing"
+
+func TestFlattenGoName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Request_Body", "RequestBody"},
+		{"Request_Item", "RequestItem"},
+		{"UpdateInstanceByUUIDRequest_Body", "UpdateInstanceByUUIDRequestBody"},
+		{"A_B_C", "ABC"},
+		// Top-level names must pass through unchanged.
+		{"CreateInstanceRequest", "CreateInstanceRequest"},
+		{"GetInstancesResponse", "GetInstancesResponse"},
+		{"Body", "Body"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := flattenGoName(tt.input)
+			if got != tt.want {
+				t.Errorf("flattenGoName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/protoc-gen-go-struct/main.go
+++ b/tools/protoc-gen-go-struct/main.go
@@ -112,6 +112,9 @@ func generateFile(plugin *protogen.Plugin, file *protogen.File, basePackage stri
 	templateData.Structs = templateData.getStructs(file.Messages...)
 	templateData.Enums = templateData.getEnums(file.Enums)
 
+	// Also collect nested enums from messages
+	templateData.Enums = append(templateData.Enums, templateData.collectNestedEnums(file.Messages)...)
+
 	tmpl, err := template.ParseFS(tmpl, "struct.tmpl")
 	if err != nil {
 		return err
@@ -257,9 +260,9 @@ func (td *TemplateData) getStructs(messages ...*protogen.Message) map[string]Str
 				if enumImportPath != td.GoImportPath {
 					alias := generatePackageAlias(enumPath)
 					td.Imports[alias] = enumImportPath
-					f.Type = alias + "." + string(field.Enum.Desc.Name())
+					f.Type = alias + "." + strings.ReplaceAll(field.Enum.GoIdent.GoName, "_", "")
 				} else {
-					f.Type = string(field.Enum.Desc.Name())
+					f.Type = strings.ReplaceAll(field.Enum.GoIdent.GoName, "_", "")
 				}
 			} else if field.Desc.Kind() == protoreflect.MessageKind {
 				switch field.Desc.Message().FullName() {
@@ -277,23 +280,18 @@ func (td *TemplateData) getStructs(messages ...*protogen.Message) map[string]Str
 				case "google.protobuf.Value":
 					f.Type = "*structpb.Value"
 				default:
-					// Check if the message is embedded (i.e., not top-level)
-					if field.Message != nil && field.Desc.Message().Parent() != nil && field.Desc.Message().Parent().Parent() != nil {
-						// Embedded message: prefix with parent type.
-						f.Type = strings.ReplaceAll(m.GoIdent.GoName, "_", "") + string(field.Desc.Message().Name())
-						field.Message.GoIdent.GoName = f.Type // Update GoIdent for embedded messages
-					} else {
-						messagePath := string(field.Desc.Message().ParentFile().Path())
-						messageImportPath := resolveImportPath(messagePath, td.BasePackage)
+					flatName := strings.ReplaceAll(field.Message.GoIdent.GoName, "_", "")
+					messagePath := string(field.Desc.Message().ParentFile().Path())
+					messageImportPath := resolveImportPath(messagePath, td.BasePackage)
 
-						if messageImportPath != td.GoImportPath {
-							alias := generatePackageAlias(messagePath)
-							td.Imports[alias] = messageImportPath
-							f.Type = alias + "." + string(field.Desc.Message().Name())
-						} else {
-							f.Type = string(field.Desc.Message().Name())
-						}
+					if messageImportPath != td.GoImportPath {
+						alias := generatePackageAlias(messagePath)
+						td.Imports[alias] = messageImportPath
+						f.Type = alias + "." + flatName
+					} else {
+						f.Type = flatName
 					}
+					field.Message.GoIdent.GoName = flatName
 					if field.Desc.HasOptionalKeyword() {
 						f.Type = "*" + f.Type
 					}
@@ -360,26 +358,28 @@ func (td *TemplateData) getStructs(messages ...*protogen.Message) map[string]Str
 				var valueTypeName string
 				switch valueKind {
 				case protoreflect.MessageKind:
+					valueFlatName := strings.ReplaceAll(valueField.Message.GoIdent.GoName, "_", "")
 					valuePath := string(valueField.Desc.Message().ParentFile().Path())
 					valueImportPath := resolveImportPath(valuePath, td.BasePackage)
 
 					if valueImportPath != td.GoImportPath {
 						alias := generatePackageAlias(valuePath)
 						td.Imports[alias] = valueImportPath
-						valueTypeName = alias + "." + string(valueField.Desc.Message().Name())
+						valueTypeName = alias + "." + valueFlatName
 					} else {
-						valueTypeName = string(valueField.Desc.Message().Name())
+						valueTypeName = valueFlatName
 					}
 				case protoreflect.EnumKind:
+					enumFlatName := strings.ReplaceAll(valueField.Enum.GoIdent.GoName, "_", "")
 					valuePath := string(valueField.Desc.Enum().ParentFile().Path())
 					valueImportPath := resolveImportPath(valuePath, td.BasePackage)
 
 					if valueImportPath != td.GoImportPath {
 						alias := generatePackageAlias(valuePath)
 						td.Imports[alias] = valueImportPath
-						valueTypeName = alias + "." + string(valueField.Desc.Enum().Name())
+						valueTypeName = alias + "." + enumFlatName
 					} else {
-						valueTypeName = string(valueField.Desc.Enum().Name())
+						valueTypeName = enumFlatName
 					}
 				default:
 					valueTypeName = valueKind.String()
@@ -408,22 +408,36 @@ func camelToSnakeUpper(s string) string {
 	return strings.ToUpper(result.String())
 }
 
+func (td *TemplateData) collectNestedEnums(messages []*protogen.Message) []Enum {
+	var result []Enum
+	for _, m := range messages {
+		if len(m.Enums) > 0 {
+			result = append(result, td.getEnums(m.Enums)...)
+		}
+		if len(m.Messages) > 0 {
+			result = append(result, td.collectNestedEnums(m.Messages)...)
+		}
+	}
+	return result
+}
+
 func (td *TemplateData) getEnums(enums []*protogen.Enum) []Enum {
 	var data []Enum
 
 	for _, e := range enums {
+		flatName := strings.ReplaceAll(e.GoIdent.GoName, "_", "")
 		s := Enum{
-			Name:    e.GoIdent.GoName,
+			Name:    flatName,
 			Comment: e.Comments.Leading.String(),
 		}
 
 		for _, value := range e.Values {
 			v := EnumValue{
-				Name:    strcase.ToCamel(strings.TrimPrefix(value.GoIdent.GoName, s.Name+"_")),
+				Name:    strcase.ToCamel(strings.TrimPrefix(value.GoIdent.GoName, e.GoIdent.GoName+"_")),
 				Comment: value.Comments.Leading.String(),
 			}
 
-			v.ID = strings.ToLower(strings.TrimPrefix(strings.TrimPrefix(value.GoIdent.GoName, s.Name+"_"), camelToSnakeUpper(s.Name)+"_"))
+			v.ID = strings.ToLower(strings.TrimPrefix(strings.TrimPrefix(value.GoIdent.GoName, e.GoIdent.GoName+"_"), camelToSnakeUpper(e.GoIdent.GoName)+"_"))
 
 			s.Values = append(s.Values, v)
 		}

--- a/tools/protoc-gen-go-struct/main.go
+++ b/tools/protoc-gen-go-struct/main.go
@@ -231,7 +231,7 @@ func (td *TemplateData) getStructs(messages ...*protogen.Message) map[string]Str
 
 	for _, m := range messages {
 		s := Struct{
-			Name:    m.GoIdent.GoName,
+			Name:    strings.ReplaceAll(m.GoIdent.GoName, "_", ""),
 			Comment: m.Comments.Leading.String(),
 		}
 
@@ -280,7 +280,7 @@ func (td *TemplateData) getStructs(messages ...*protogen.Message) map[string]Str
 					// Check if the message is embedded (i.e., not top-level)
 					if field.Message != nil && field.Desc.Message().Parent() != nil && field.Desc.Message().Parent().Parent() != nil {
 						// Embedded message: prefix with parent type.
-						f.Type = m.GoIdent.GoName + string(field.Desc.Message().Name())
+						f.Type = strings.ReplaceAll(m.GoIdent.GoName, "_", "") + string(field.Desc.Message().Name())
 						field.Message.GoIdent.GoName = f.Type // Update GoIdent for embedded messages
 					} else {
 						messagePath := string(field.Desc.Message().ParentFile().Path())
@@ -391,7 +391,7 @@ func (td *TemplateData) getStructs(messages ...*protogen.Message) map[string]Str
 			s.Fields = append(s.Fields, f)
 		}
 
-		data[m.GoIdent.GoName] = s
+		data[strings.ReplaceAll(m.GoIdent.GoName, "_", "")] = s
 	}
 
 	return data

--- a/tools/protoc-gen-go-struct/main.go
+++ b/tools/protoc-gen-go-struct/main.go
@@ -273,7 +273,9 @@ func (td *TemplateData) getStructs(messages ...*protogen.Message) map[string]Str
 						f.Type = "*" + f.Type
 					}
 				case "google.protobuf.Empty":
-					f.Type = "structpb.Empty"
+					f.Type = "emptypb.Empty"
+				case "google.protobuf.Value":
+					f.Type = "*structpb.Value"
 				default:
 					// Check if the message is embedded (i.e., not top-level)
 					if field.Message != nil && field.Desc.Message().Parent() != nil && field.Desc.Message().Parent().Parent() != nil {

--- a/tools/protoc-gen-go-struct/main.go
+++ b/tools/protoc-gen-go-struct/main.go
@@ -33,6 +33,7 @@ type TemplateData struct {
 	OmitPathParams  bool
 	Version         string
 	Package         string
+	GoImportPath    string            // resolved Go import path for the current file
 	Imports         map[string]string // package alias -> import path
 	Structs         map[string]Struct
 	Enums           []Enum
@@ -98,6 +99,7 @@ func generateFile(plugin *protogen.Plugin, file *protogen.File, basePackage stri
 		NativeTime:      nativeTime,
 		OmitPathParams:  omitPathParams,
 		Package:         string(file.GoPackageName),
+		GoImportPath:    resolveImportPath(string(file.Desc.Path()), basePackage),
 		Imports:         make(map[string]string),
 		PathParamFields: make(map[string]map[string]bool),
 	}
@@ -249,14 +251,12 @@ func (td *TemplateData) getStructs(messages ...*protogen.Message) map[string]Str
 			}
 
 			if field.Enum != nil {
-				// Check if enum comes from a different package
 				enumPath := string(field.Enum.Desc.ParentFile().Path())
-				currentPath := string(m.Desc.ParentFile().Path())
+				enumImportPath := resolveImportPath(enumPath, td.BasePackage)
 
-				if enumPath != currentPath {
-					// Enum is from a different package - add import
+				if enumImportPath != td.GoImportPath {
 					alias := generatePackageAlias(enumPath)
-					td.Imports[alias] = resolveImportPath(enumPath, td.BasePackage)
+					td.Imports[alias] = enumImportPath
 					f.Type = alias + "." + string(field.Enum.Desc.Name())
 				} else {
 					f.Type = string(field.Enum.Desc.Name())
@@ -281,17 +281,14 @@ func (td *TemplateData) getStructs(messages ...*protogen.Message) map[string]Str
 						f.Type = m.GoIdent.GoName + string(field.Desc.Message().Name())
 						field.Message.GoIdent.GoName = f.Type // Update GoIdent for embedded messages
 					} else {
-						// Check if message comes from a different package
 						messagePath := string(field.Desc.Message().ParentFile().Path())
-						currentPath := string(m.Desc.ParentFile().Path())
+						messageImportPath := resolveImportPath(messagePath, td.BasePackage)
 
-						if messagePath != currentPath {
-							// Message is from a different package - add import
+						if messageImportPath != td.GoImportPath {
 							alias := generatePackageAlias(messagePath)
-							td.Imports[alias] = resolveImportPath(messagePath, td.BasePackage)
+							td.Imports[alias] = messageImportPath
 							f.Type = alias + "." + string(field.Desc.Message().Name())
 						} else {
-							// Top-level message in same package: just use the message name.
 							f.Type = string(field.Desc.Message().Name())
 						}
 					}
@@ -361,27 +358,23 @@ func (td *TemplateData) getStructs(messages ...*protogen.Message) map[string]Str
 				var valueTypeName string
 				switch valueKind {
 				case protoreflect.MessageKind:
-					// Check if message comes from a different package
 					valuePath := string(valueField.Desc.Message().ParentFile().Path())
-					currentPath := string(m.Desc.ParentFile().Path())
+					valueImportPath := resolveImportPath(valuePath, td.BasePackage)
 
-					if valuePath != currentPath {
-						// Message is from a different package - add import
+					if valueImportPath != td.GoImportPath {
 						alias := generatePackageAlias(valuePath)
-						td.Imports[alias] = resolveImportPath(valuePath, td.BasePackage)
+						td.Imports[alias] = valueImportPath
 						valueTypeName = alias + "." + string(valueField.Desc.Message().Name())
 					} else {
 						valueTypeName = string(valueField.Desc.Message().Name())
 					}
 				case protoreflect.EnumKind:
-					// Check if enum comes from a different package
 					valuePath := string(valueField.Desc.Enum().ParentFile().Path())
-					currentPath := string(m.Desc.ParentFile().Path())
+					valueImportPath := resolveImportPath(valuePath, td.BasePackage)
 
-					if valuePath != currentPath {
-						// Enum is from a different package - add import
+					if valueImportPath != td.GoImportPath {
 						alias := generatePackageAlias(valuePath)
-						td.Imports[alias] = resolveImportPath(valuePath, td.BasePackage)
+						td.Imports[alias] = valueImportPath
 						valueTypeName = alias + "." + string(valueField.Desc.Enum().Name())
 					} else {
 						valueTypeName = string(valueField.Desc.Enum().Name())

--- a/tools/protoc-gen-go-struct/main_test.go
+++ b/tools/protoc-gen-go-struct/main_test.go
@@ -38,6 +38,11 @@ func TestBufGenerate(t *testing.T) {
 			bufDir:        "testdata/self-reference/",
 			generationDir: "dist/self-reference",
 		},
+		{
+			name:          "well-known-types",
+			bufDir:        "testdata/well-known-types/",
+			generationDir: "dist/well-known-types",
+		},
 	}
 
 	for _, tt := range tests {

--- a/tools/protoc-gen-go-struct/main_test.go
+++ b/tools/protoc-gen-go-struct/main_test.go
@@ -33,6 +33,11 @@ func TestBufGenerate(t *testing.T) {
 			bufDir:        "testdata/multiple-definitions/",
 			generationDir: "dist/multiple-definitions",
 		},
+		{
+			name:          "self-reference",
+			bufDir:        "testdata/self-reference/",
+			generationDir: "dist/self-reference",
+		},
 	}
 
 	for _, tt := range tests {

--- a/tools/protoc-gen-go-struct/struct.tmpl
+++ b/tools/protoc-gen-go-struct/struct.tmpl
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 {{- range $alias, $path := .Imports }}
 	{{ $alias }} "{{ $path }}"
@@ -16,6 +17,7 @@ import (
 var (
 	_ time.Time
 	_ emptypb.Empty
+	_ structpb.Value
 	_ timestamppb.Timestamp
 )
 

--- a/tools/protoc-gen-go-struct/testdata/self-reference/buf.gen.yaml
+++ b/tools/protoc-gen-go-struct/testdata/self-reference/buf.gen.yaml
@@ -1,0 +1,14 @@
+version: v2
+managed:
+  enabled: false
+
+inputs:
+  - directory: testdata/self-reference
+
+plugins:
+- local: ["go", "run", "main.go"]
+  types:
+  - "api.example.instances.v1.GetInstanceRequest"
+  out: dist/self-reference
+  opt:
+  - base_package=github.com/example/project/api

--- a/tools/protoc-gen-go-struct/testdata/self-reference/buf.yaml
+++ b/tools/protoc-gen-go-struct/testdata/self-reference/buf.yaml
@@ -1,0 +1,2 @@
+version: v1
+name: buf.build/local/protoc-gen-go-struct-test

--- a/tools/protoc-gen-go-struct/testdata/self-reference/instances/v1/instances.proto
+++ b/tools/protoc-gen-go-struct/testdata/self-reference/instances/v1/instances.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package api.example.instances.v1;
+
+option go_package = "instances/v1;instancesv1";
+
+message Instance {
+  string name = 1;
+  string status = 2;
+}

--- a/tools/protoc-gen-go-struct/testdata/self-reference/instances/v1/service.proto
+++ b/tools/protoc-gen-go-struct/testdata/self-reference/instances/v1/service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package api.example.instances.v1;
+
+import "instances/v1/instances.proto";
+
+option go_package = "instances/v1;instancesv1";
+
+message GetInstanceRequest {
+  string name = 1;
+}
+
+message GetInstanceResponse {
+  Instance instance = 1;
+}

--- a/tools/protoc-gen-go-struct/testdata/well-known-types/buf.gen.yaml
+++ b/tools/protoc-gen-go-struct/testdata/well-known-types/buf.gen.yaml
@@ -1,0 +1,14 @@
+version: v2
+managed:
+  enabled: false
+
+inputs:
+  - directory: testdata/well-known-types
+
+plugins:
+- local: ["go", "run", "main.go"]
+  types:
+  - "api.example.wellknown.v1.ResourceWithMetadata"
+  out: dist/well-known-types
+  opt:
+  - base_package=github.com/example/project/api

--- a/tools/protoc-gen-go-struct/testdata/well-known-types/buf.yaml
+++ b/tools/protoc-gen-go-struct/testdata/well-known-types/buf.yaml
@@ -1,0 +1,2 @@
+version: v1
+name: buf.build/local/protoc-gen-go-struct-test

--- a/tools/protoc-gen-go-struct/testdata/well-known-types/wellknown/v1/wellknown.proto
+++ b/tools/protoc-gen-go-struct/testdata/well-known-types/wellknown/v1/wellknown.proto
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+syntax = "proto3";
+
+package api.example.wellknown.v1;
+
+option go_package = "wellknown/v1;wellknownv1";
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/empty.proto";
+
+// ResourceWithMetadata is a test message that uses well-known types
+// google.protobuf.Value and google.protobuf.Empty.
+message ResourceWithMetadata {
+  string name = 1;
+  google.protobuf.Value metadata = 2;
+  google.protobuf.Empty empty_field = 3;
+}


### PR DESCRIPTION
Fixes several bugs in `protoc-gen-go-struct` and `protoc-gen-go-gin` where nested protobuf types caused incorrect code generation:

- **Self-referencing imports**: Compare resolved Go import paths instead of proto file paths to avoid import cycles when multiple `.proto` files share the same Go package.
- **Flat naming for nested types**: Strip underscores from protobuf's `Parent_Child` naming to match the struct generator's `ParentChild` convention. Applied consistently across both generators.
- **Pointer/value mismatch**: Pass `&body` (pointer) for message-type body fields in gin handlers; leave slices as-is since they're already reference types.
- **Well-known type fixes**: Add missing `google.protobuf.Value` → `*structpb.Value` mapping; fix `google.protobuf.Empty` → `emptypb.Empty`.
- **Nested enum collection**: Recursively collect enums defined inside message scopes.

Adds unit tests for `flattenGoName` and integration test fixtures (`self-reference`, `well-known-types`) for the struct generator.

