### PR TITLE
fix(tools/openapi-gen): Minor fixes in Go module definition

### DIFF
--- a/tools/openapi-gen/go.mod
+++ b/tools/openapi-gen/go.mod
@@ -1,4 +1,4 @@
-module unikraft.com/cloud/sdk/tools/codegen
+module unikraft.com/x/tools/openapi-gen
 
 go 1.24.0
 

--- a/tools/openapi-gen/go.mod
+++ b/tools/openapi-gen/go.mod
@@ -1,6 +1,6 @@
 module unikraft.com/x/tools/openapi-gen
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
- **fix(tools/openapi-gen): Correct Go module name**
- **build(deps): Bump Go 1.24.0 to 1.26.1 in tools/openapi-gen**
