### PR TITLE
fix(kraftfile): Validate source type on unmarshal

### DIFF
--- a/kraftfile/parse.go
+++ b/kraftfile/parse.go
@@ -9,6 +9,7 @@ import (
 	"cmp"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -278,12 +279,10 @@ func (fsType *FsType) UnmarshalJSON(data []byte) error {
 	case nil:
 		return nil
 	case string:
-		switch value {
-		case "cpio", "erofs":
-			*fsType = FsType(value)
-		default:
+		if !slices.Contains(FsTypes, FsType(value)) {
 			return fmt.Errorf("invalid fs type %q", value)
 		}
+		*fsType = FsType(value)
 		return nil
 	default:
 		return fmt.Errorf("invalid fs value type %T", raw)
@@ -300,12 +299,10 @@ func (srcType *SourceType) UnmarshalJSON(data []byte) error {
 	case nil:
 		return nil
 	case string:
-		switch value {
-		case "oci", "dir", "file", "tarball", "cpio", "erofs", "dockerfile":
-			*srcType = SourceType(value)
-		default:
+		if !slices.Contains(SourceTypes, SourceType(value)) {
 			return fmt.Errorf("invalid source type %q", value)
 		}
+		*srcType = SourceType(value)
 		return nil
 	default:
 		return fmt.Errorf("invalid source value type %T", raw)

--- a/kraftfile/parse.go
+++ b/kraftfile/parse.go
@@ -286,7 +286,29 @@ func (fsType *FsType) UnmarshalJSON(data []byte) error {
 		}
 		return nil
 	default:
-		return fmt.Errorf("invalid fsType value type %T", raw)
+		return fmt.Errorf("invalid fs value type %T", raw)
+	}
+}
+
+func (srcType *SourceType) UnmarshalJSON(data []byte) error {
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	switch value := raw.(type) {
+	case nil:
+		return nil
+	case string:
+		switch value {
+		case "oci", "dir", "file", "tarball", "cpio", "erofs", "dockerfile":
+			*srcType = SourceType(value)
+		default:
+			return fmt.Errorf("invalid source type %q", value)
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid source value type %T", raw)
 	}
 }
 

--- a/kraftfile/spec.go
+++ b/kraftfile/spec.go
@@ -107,6 +107,11 @@ const (
 	FsTypeErofs = FsType("erofs")
 )
 
+var FsTypes = []FsType{
+	FsTypeCpio,
+	FsTypeErofs,
+}
+
 func (fsType FsType) String() string {
 	return string(fsType)
 }
@@ -122,6 +127,16 @@ const (
 	SourceTypeErofs      = SourceType("erofs")
 	SourceTypeDockerfile = SourceType("dockerfile")
 )
+
+var SourceTypes = []SourceType{
+	SourceTypeOCI,
+	SourceTypeDirectory,
+	SourceTypeFile,
+	SourceTypeTarball,
+	SourceTypeCpio,
+	SourceTypeErofs,
+	SourceTypeDockerfile,
+}
 
 func (sourceType SourceType) String() string {
 	return string(sourceType)


### PR DESCRIPTION
Like we do with the other types. This means we don't need further validation downstream.