### PR TITLE
fix(kraftfile)!: Remove setting default format

### DIFF
--- a/kraftfile/parse.go
+++ b/kraftfile/parse.go
@@ -265,7 +265,6 @@ func (fs *FS) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("invalid fs value type %T", raw)
 	}
 
-	fs.Format = cmp.Or(fs.Format, FsTypeCpio)
 	return nil
 }
 

--- a/kraftfile/parse_test.go
+++ b/kraftfile/parse_test.go
@@ -144,7 +144,7 @@ rootfs: ./Dockerfile
 	require.NoError(t, err)
 	require.NotNil(t, doc.Rootfs)
 	require.Equal(t, "./Dockerfile", doc.Rootfs.Source)
-	require.Equal(t, FsTypeCpio, doc.Rootfs.Format)
+	require.Empty(t, doc.Rootfs.Format)
 
 	input = `spec: v0.7
 rootfs:


### PR DESCRIPTION
We should instead detect what we can use from the runtime. If nothing is set, we should default to cpio in the implementations.