### PR TITLE
fix: Skip OTLP initialization if no OTLP endpoint specified

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -31,6 +31,9 @@ func Init(ctx context.Context) (func(context.Context) error, error) {
 	if disabled {
 		return noop, nil
 	}
+	if os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") == "" {
+		return noop, nil
+	}
 
 	res, err := resource.New(ctx,
 		resource.WithFromEnv(),


### PR DESCRIPTION
This just defaults to localhost if not set. Which is weird, and probably not the intended behavior.