### PR TITLE
fix(openapi-gen): Use parallel generation

### DIFF
--- a/tools/openapi-gen/go.mod
+++ b/tools/openapi-gen/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/go-wordwrap v1.0.1
+	golang.org/x/sync v0.20.0
 	golang.org/x/tools v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 	unikraft.com/x/kingkong v0.0.0-20260105163520-49d071286efd
@@ -63,7 +64,6 @@ require (
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.54.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	unikraft.com/x/colors v0.0.0-20260105163520-49d071286efd // indirect

--- a/tools/openapi-gen/main.go
+++ b/tools/openapi-gen/main.go
@@ -8,8 +8,10 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/alecthomas/kong"
+	"golang.org/x/sync/errgroup"
 	"unikraft.com/x/kingkong"
 )
 
@@ -68,10 +70,18 @@ func run(cli *cli) error {
 
 	files := generator.GenerateAll()
 
+	eg := new(errgroup.Group)
+	eg.SetLimit(runtime.GOMAXPROCS(0))
 	for _, file := range files {
-		if err := file.Generate(generator.templates, cli.Output); err != nil {
-			return fmt.Errorf("error generating %s: %w", file.Basename, err)
-		}
+		eg.Go(func() error {
+			if err := file.Generate(generator.templates, cli.Output); err != nil {
+				return fmt.Errorf("error generating %s: %w", file.Basename, err)
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return err
 	}
 
 	fmt.Println("Code generation completed successfully!")


### PR DESCRIPTION
go-imports can be a bit slow - so let's parallelize any network calls we need to do.