### PR TITLE
fix(license-check): Match against the relative path

### DIFF
--- a/tools/license-check/walk.go
+++ b/tools/license-check/walk.go
@@ -79,7 +79,7 @@ func (f *fileFilter) collect(paths []string) ([]string, error) {
 			if IsFragmentFile(d.Name()) {
 				return nil
 			}
-			if !f.match(path) {
+			if !f.match(rel) {
 				return nil
 			}
 			add(path)


### PR DESCRIPTION
Without this it is not possible to exclude based on the full path, since it is rooted in the filesystem of the host, which probably differs per checkout.