### PR TITLE
chore(taskfile): Cleanup lint task

### DIFF
--- a/Taskfile.go.yml
+++ b/Taskfile.go.yml
@@ -178,29 +178,28 @@ tasks:
     vars:
       package:
         ref: .package | default "./..."
+      config:
+        sh: |
+          for c in .golangci.{yml,yaml,toml,json}; do
+            if [ -f "$c" ]; then echo "$c" && exit 0; fi
+          done
+          mktemp --dry-run --tmpdir builtin-golangci-XXXX.yml
     env:
       GOLANGCI_CONFIG: "{{.golangci_config}}"
-    cmd: |
-      config_flag=""
-      if [ -f .golangci.yml ] || [ -f .golangci.yaml ] || \
-         [ -f .golangci.toml ] || [ -f .golangci.json ]; then
-        : # use the module's own config (golangci-lint auto-discovers it)
-      else
-        config_dir="$(mktemp -d)"
-        trap 'rm -rf "${config_dir}"' EXIT
-        config="${config_dir}/golangci.yml"
-        printf '%s\n' "${GOLANGCI_CONFIG}" > "${config}"
-        config_flag="--config ${config}"
-      fi
-      {{.golangci_bin}} run \
-        ${config_flag} \
-        --build-tags='{{.go_tags}}' \
-        --timeout=10m \
-        --show-stats=false \
-        --output.text.path=stderr \
-        {{.golangci_args}} \
-        {{.CLI_ARGS}} \
-        {{.package}}
+    cmds:
+    - '{{if regexMatch "builtin-golangci" .config}}echo "${GOLANGCI_CONFIG}" > {{.config}}{{end}}'
+    - defer: '{{if regexMatch "builtin-golangci" .config}}rm -f {{.config}}{{end}}'
+    - >-
+      {{.golangci_bin}} run
+      --config='{{.config}}'
+      --path-prefix='{{.TASKFILE_DIR}}'
+      --build-tags='{{.go_tags}}'
+      --timeout=10m
+      --show-stats=false
+      --output.text.path=stderr
+      {{.golangci_args}}
+      {{.CLI_ARGS}}
+      {{.package}}
 
   fmt:
     desc: "Run gofumpt"

--- a/Taskfile.go.yml
+++ b/Taskfile.go.yml
@@ -179,16 +179,12 @@ tasks:
       package:
         ref: .package | default "./..."
       config:
-        sh: |
-          for c in .golangci.{yml,yaml,toml,json}; do
-            if [ -f "$c" ]; then echo "$c" && exit 0; fi
-          done
-          mktemp --dry-run --tmpdir builtin-golangci-XXXX.yml
+        sh: mktemp --dry-run --tmpdir builtin-golangci-XXXX.yml
     env:
       GOLANGCI_CONFIG: "{{.golangci_config}}"
     cmds:
-    - '{{if regexMatch "builtin-golangci" .config}}echo "${GOLANGCI_CONFIG}" > {{.config}}{{end}}'
-    - defer: '{{if regexMatch "builtin-golangci" .config}}rm -f {{.config}}{{end}}'
+    - echo "${GOLANGCI_CONFIG}" > {{.config}}
+    - defer: rm -f {{.config}}
     - >-
       {{.golangci_bin}} run
       --config='{{.config}}'


### PR DESCRIPTION
Determine the config path using a dynamic variable and then only run
additional commands if we are creating the file from builtin
configuration.

This makes it so that for projects which ship their own config, only the
actual linter invocation runs.

Also sets the path-prefix option, to avoid suprises when the config is not
located in the working directory. Golangci interprets paths passed to the
output options as relative to config.

Signed-off-by: Robert Günzler <robert@unikraft.cloud>
