### PR TITLE
fix: Allow custom lint config

### DIFF
--- a/Taskfile.go.yml
+++ b/Taskfile.go.yml
@@ -29,7 +29,7 @@ vars:
     ref: .gotestsum_version | default "latest"
   gotestsum_bin: "{{.go_bin}} run gotest.tools/gotestsum@{{.gotestsum_version}}"
 
-  golangci_config: |
+  _golangci_config_default: |
     version: "2"
     run:
       issues-exit-code: 2
@@ -88,6 +88,8 @@ vars:
         - tmp/
         - dist/
         - examples$
+
+  golangci_config: '{{.golangci_config | default ._golangci_config_default}}'
 
 tasks:
   generate:


### PR DESCRIPTION
This modifies the shared taskfile to allow custom linter config to be supplied instead of using the default config. Therefore stricter linter configuration can be used or some rules can be temporarily disabled if needed.

Signed-off-by: Arturs Janis Petersons <arturs@unikraft.io>