### PR TITLE
fix(openapi-gen): Miscellaneous improvements

### DIFF
--- a/tools/openapi-gen/README.md
+++ b/tools/openapi-gen/README.md
@@ -42,17 +42,31 @@ go run unikraft.com/x/tools/openapi-gen@latest \
   -t github.com/org/repo@main#dir=templates/go-client
 ```
 
-| Flag          | Short | Description                                                          |
-| ------------- | ----- | -------------------------------------------------------------------- |
-| `--input`     | `-i`  | Path, URL, or Git ref to the OpenAPI spec (required)                 |
-| `--output`    | `-o`  | Output directory for generated files (required)                      |
-| `--var`       | `-v`  | Set a template variable as `key=value` (repeatable)                  |
-| `--templates` | `-t`  | Directory or Git ref to template overrides (required)                |
-| `--package`   |       | Filter to schemas/operations whose `x-package` matches this value    |
+| Flag                 | Short | Description                                                                |
+| -------------------- | ----- | --------------------------------------------------------------------------|
+| `--input`            | `-i`  | Path, URL, or Git ref to the OpenAPI spec (required)                      |
+| `--output`           | `-o`  | Output directory for generated files (required)                           |
+| `--var`              | `-v`  | Set a template variable as `key=value` (repeatable)                       |
+| `--templates`        | `-t`  | Directory or Git ref to template overrides (required)                    |
+| `--package`          |       | Filter to schemas/operations whose `x-package` matches this value        |
+| `--tag`              |       | Filter to operations carrying one of these tags (repeatable)              |
+| `--namespace`        |       | Filter to schemas in one of these namespaces, e.g. `Instances` (repeatable) |
+| `--namespace-flatten`|       | Rewrite namespaced schema names: `strip` drops the prefix, `join` concatenates segments |
 
 When `--package` is set, only schemas and operations whose `x-package` extension
 matches the given value are passed to templates. The value is also exposed to
 templates as the `x-package` variable (i.e. `{{ .Var "x-package" "" }}`).
+
+`--tag` and `--namespace` are the `x-package`-free equivalent, matching how
+platform-api's TypeSpec compiler shapes its output: operations are tagged per
+resource and models are named `Namespace.Type` (e.g. `Instances.Instance`).
+`--tag` filters operations by their OpenAPI `tags`; `--namespace` filters
+models by the prefix of their schema name. Since `Namespace.Type` isn't a
+valid Go identifier, pair `--namespace` with `--namespace-flatten` to strip or
+join the prefix once filtering is done. When exactly one `--namespace` is
+given, its lowercased value is also exposed to templates as the
+`current_package` variable, for distinguishing local from foreign type
+references.
 
 ## Internals
 

--- a/tools/openapi-gen/README.md
+++ b/tools/openapi-gen/README.md
@@ -48,14 +48,19 @@ go run unikraft.com/x/tools/openapi-gen@latest \
 | `--output`           | `-o`  | Output directory for generated files (required)                           |
 | `--var`              | `-v`  | Set a template variable as `key=value` (repeatable)                       |
 | `--templates`        | `-t`  | Directory or Git ref to template overrides (required)                    |
-| `--package`          |       | Filter to schemas/operations whose `x-package` matches this value        |
+| `--package`          |       | Deprecated: use `--tag`/`--namespace` instead. Filter to schemas/operations whose `x-package` matches this value |
 | `--tag`              |       | Filter to operations carrying one of these tags (repeatable)              |
 | `--namespace`        |       | Filter to schemas in one of these namespaces, e.g. `Instances` (repeatable) |
 | `--namespace-flatten`|       | Rewrite namespaced schema names: `strip` drops the prefix, `join` concatenates segments |
 
-When `--package` is set, only schemas and operations whose `x-package` extension
-matches the given value are passed to templates. The value is also exposed to
+`--package` is deprecated: it only works against specs produced by our
+proto-based pipeline, which stamps schemas and operations with an `x-package`
+extension. When set, only schemas and operations whose `x-package` matches
+the given value are passed to templates, and the value is also exposed to
 templates as the `x-package` variable (i.e. `{{ .Var "x-package" "" }}`).
+Existing proto-sourced callers keep working, but new ones should use
+`--tag`/`--namespace` below; `--package` will be removed once those callers
+have migrated.
 
 `--tag` and `--namespace` are the `x-package`-free equivalent, matching how
 platform-api's TypeSpec compiler shapes its output: operations are tagged per
@@ -134,7 +139,7 @@ Templates have access to all [Sprig](https://masterminds.github.io/sprig/) funct
 | `propertyNamesOrdered`  | `schemaName, schema → []string` | Property names in YAML source order                            |
 | `getProperty`           | `schema, name → *Schema`        | Get a property schema (traverses `allOf`)                      |
 | `getPropertyRequired`   | `schema, name → bool`           | True if property is required (traverses `allOf`)               |
-| `getTypePackage`        | `v → string`                    | Return `x-package` for a type ref (accepts `*Schema`, `*SchemaRef`, `*Parameter`, or `string`) |
+| `getTypePackage`        | `v → string`                    | Deprecated (proto-only): return `x-package` for a type ref (accepts `*Schema`, `*SchemaRef`, `*Parameter`, or `string`) |
 
 ### Iteration helpers
 

--- a/tools/openapi-gen/README.md
+++ b/tools/openapi-gen/README.md
@@ -78,8 +78,9 @@ references.
 ### Processing pipeline
 
 1. **Parse** — Load the OpenAPI spec with `kin-openapi`, extract YAML property ordering from the raw document.
-2. **Preprocess** — Flatten `allOf` wrappers around `$ref`, promote inline object/enum schemas to top-level `components/schemas` entries, assign type names to inline enums.
-3. **Generate** — Execute each template against a `TemplateData` value, `gofmt` the output, and write files.
+2. **Preprocess** — Hoist inline object/enum schemas (found via properties, composition, or array items) to top-level `components/schemas` entries, so every type a generator needs has a name.
+3. **Filter/flatten** — Apply `--package`, `--tag`, and `--namespace` filtering, then `--namespace-flatten` to rewrite namespaced schema names into valid Go identifiers.
+4. **Generate** — Execute each template against a `TemplateData` value, `gofmt` the output, and write files.
 
 ### Template data
 
@@ -136,8 +137,8 @@ Templates have access to all [Sprig](https://masterminds.github.io/sprig/) funct
 
 | Function               | Signature                       | Description                                                    |
 | ---------------------- | ------------------------------- | -------------------------------------------------------------- |
-| `propertyNamesOrdered`  | `schemaName, schema → []string` | Property names in YAML source order                            |
-| `getProperty`           | `schema, name → *Schema`        | Get a property schema (traverses `allOf`)                      |
+| `propertyNamesOrdered`  | `schemaName, schema → []string` | Property names in YAML source order, falling back to sorted composition order |
+| `getProperty`           | `schema, name → *Schema`        | Get a property schema (traverses `allOf`/`oneOf`/`anyOf`)      |
 | `getPropertyRequired`   | `schema, name → bool`           | True if property is required (traverses `allOf`)               |
 | `getTypePackage`        | `v → string`                    | Deprecated (proto-only): return `x-package` for a type ref (accepts `*Schema`, `*SchemaRef`, `*Parameter`, or `string`) |
 

--- a/tools/openapi-gen/funcs.go
+++ b/tools/openapi-gen/funcs.go
@@ -95,7 +95,7 @@ func (tf *templateFuncs) inlineEnums(schemaName string, schema *openapi3.Schema)
 		if len(prop.Enum) > 0 && prop.Title != "" {
 			result = append(result, inlineEnum{Name: prop.Title, Schema: prop})
 		}
-		if prop.Type != nil && prop.Type.Is("array") && prop.Items != nil && prop.Items.Value != nil {
+		if prop.Type != nil && prop.Type.Is("array") && prop.Items != nil && prop.Items.Ref == "" && prop.Items.Value != nil {
 			item := prop.Items.Value
 			if len(item.Enum) > 0 && item.Title != "" {
 				result = append(result, inlineEnum{Name: item.Title, Schema: item})
@@ -113,122 +113,40 @@ func (tf *templateFuncs) getType(schema *openapi3.Schema) string {
 	return schema.Type.Slice()[0]
 }
 
-// propertyNamesOrdered returns property names in the order they appear in YAML
+// propertyNamesOrdered returns property names in the order they appear in YAML,
+// falling back to a deterministic flattening of the schema's composition when
+// the source order is unavailable.
 func (tf *templateFuncs) propertyNamesOrdered(schemaName string, schema *openapi3.Schema) []string {
-	// First try to get order from YAML parser
 	if order := tf.parser.GetPropertyOrder(schemaName); len(order) > 0 {
 		return order
 	}
-
-	// Fallback to collecting from schema (unordered)
-	if schema == nil {
-		return nil
-	}
-
-	names := make([]string, 0)
-	seen := make(map[string]bool)
-
-	// Collect from allOf
-	if len(schema.AllOf) > 0 {
-		for _, allOfRef := range schema.AllOf {
-			allOfSchema := allOfRef.Value
-			if allOfSchema != nil && len(allOfSchema.Properties) > 0 {
-				for name := range allOfSchema.Properties {
-					if !seen[name] {
-						names = append(names, name)
-						seen[name] = true
-					}
-				}
-			}
-			if allOfSchema != nil && len(allOfSchema.OneOf) > 0 {
-				for _, oneOfRef := range allOfSchema.OneOf {
-					oneOfSchema := oneOfRef.Value
-					if oneOfSchema != nil && len(oneOfSchema.Properties) > 0 {
-						for name := range oneOfSchema.Properties {
-							if !seen[name] {
-								names = append(names, name)
-								seen[name] = true
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
-	// Collect from direct properties
-	if len(schema.Properties) > 0 {
-		for name := range schema.Properties {
-			if !seen[name] {
-				names = append(names, name)
-				seen[name] = true
-			}
-		}
-	}
-
-	return names
+	return schemaPropertyNames(schema)
 }
 
-// getProperty returns a property schema (checking allOf too)
+// getProperty returns the schema of a named property, flattening allOf/oneOf/
+// anyOf composition to find it.
 func (tf *templateFuncs) getProperty(schema *openapi3.Schema, name string) *openapi3.Schema {
 	if schema == nil {
 		return nil
 	}
 
-	var propRef *openapi3.SchemaRef
-
-	// Check direct properties first
-	if len(schema.Properties) > 0 {
-		if ref, ok := schema.Properties[name]; ok {
-			propRef = ref
+	for _, prop := range schemaProperties(schema, true) {
+		if prop.name != name {
+			continue
 		}
-	}
 
-	// Check in allOf schemas if not found
-	if propRef == nil && len(schema.AllOf) > 0 {
-		for _, allOfRef := range schema.AllOf {
-			allOfSchema := allOfRef.Value
-			if allOfSchema != nil && len(allOfSchema.Properties) > 0 {
-				if ref, ok := allOfSchema.Properties[name]; ok {
-					propRef = ref
-					break
-				}
-			}
-			// Also check in oneOf within allOf
-			if allOfSchema != nil && len(allOfSchema.OneOf) > 0 {
-				for _, oneOfRef := range allOfSchema.OneOf {
-					oneOfSchema := oneOfRef.Value
-					if oneOfSchema != nil && len(oneOfSchema.Properties) > 0 {
-						if ref, ok := oneOfSchema.Properties[name]; ok {
-							propRef = ref
-							break
-						}
-					}
-				}
-				if propRef != nil {
-					break
-				}
+		// Normalise a direct $ref into the allOf-wrapped form so callers treat
+		// it like other optional fields: schemaToGoType extracts the type and
+		// getType returns "", so optional $ref fields get a pointer prefix.
+		if prop.ref.Ref != "" {
+			return &openapi3.Schema{
+				AllOf: []*openapi3.SchemaRef{{Ref: prop.ref.Ref}},
 			}
 		}
+		return prop.ref.Value
 	}
 
-	if propRef == nil {
-		return nil
-	}
-
-	// If it's a $ref, create a simple schema with allOf pointing to the ref.
-	// This ensures consistent handling between direct $ref and allOf: [$ref],
-	// allowing schemaToGoType to extract the type and getType to return ""
-	// (so optional $ref fields get pointer prefixes like other optional fields).
-	if propRef.Ref != "" {
-		return &openapi3.Schema{
-			AllOf: []*openapi3.SchemaRef{
-				{Ref: propRef.Ref},
-			},
-		}
-	}
-
-	return propRef.Value
+	return nil
 }
 
 // getPropertyRequired checks if a property is required (checking allOf too).

--- a/tools/openapi-gen/funcs.go
+++ b/tools/openapi-gen/funcs.go
@@ -231,6 +231,11 @@ func (tf *templateFuncs) wrapComment(text string, width int, prefix string) stri
 // getTypePackage returns the x-package value for a type reference.
 // Accepts *openapi3.Schema, *openapi3.SchemaRef, *openapi3.Parameter, or string ($ref).
 // Returns empty string if no x-package is found.
+//
+// Deprecated: x-package is only emitted by our proto-based generation
+// pipeline. New templates that need to distinguish local from foreign type
+// references should compare against the "current_package" var (set from
+// --namespace) instead.
 func (tf *templateFuncs) getTypePackage(v any) string {
 	ref := tf.extractRef(v)
 	if ref == "" {

--- a/tools/openapi-gen/generator.go
+++ b/tools/openapi-gen/generator.go
@@ -181,6 +181,58 @@ func (g *Generator) FilterByPackage(pkg string) {
 	g.models = filteredModels
 }
 
+// FilterByTag keeps only operations carrying at least one of the given tags.
+// Models are left untouched (filter them separately via FilterByNamespace).
+func (g *Generator) FilterByTag(tags []string) {
+	want := make(map[string]bool, len(tags))
+	for _, t := range tags {
+		want[t] = true
+	}
+	var filtered []PathOperation
+	for _, op := range g.operations {
+		if op.Operation == nil {
+			continue
+		}
+		for _, t := range op.Operation.Tags {
+			if want[t] {
+				filtered = append(filtered, op)
+				break
+			}
+		}
+	}
+	g.operations = filtered
+}
+
+// FilterByNamespace keeps only models belonging to one of the given namespaces.
+// Operations are left untouched (filter them separately via FilterByTag).
+func (g *Generator) FilterByNamespace(namespaces []string) {
+	want := make(map[string]bool, len(namespaces))
+	for _, ns := range namespaces {
+		want[ns] = true
+	}
+	var filtered []Model
+	for _, m := range g.models {
+		if want[m.Namespace] {
+			filtered = append(filtered, m)
+		}
+	}
+	g.models = filtered
+}
+
+// Flatten rewrites namespaced schema names (e.g. "Instances.Instance") into
+// valid Go identifiers. It runs after any namespace/tag filtering so those
+// filters can match on the original "Namespace.Name" form, and it updates the
+// already-parsed model names to stay in sync with the rewritten document.
+func (g *Generator) Flatten(mode flattenMode) {
+	if mode == flattenNone {
+		return
+	}
+	flattenNamespaces(g.parser.doc, g.parser, mode)
+	for i := range g.models {
+		g.models[i].SchemaName = flattenName(g.models[i].SchemaName, mode)
+	}
+}
+
 func loadTemplates(parser *Parser, templateDir string, models *[]Model, vars *map[string]string) (*template.Template, []string, error) {
 	if templateDir == "" {
 		return nil, nil, fmt.Errorf("template directory not specified")

--- a/tools/openapi-gen/generator.go
+++ b/tools/openapi-gen/generator.go
@@ -137,7 +137,9 @@ func NewGenerator(specPath string, vars map[string]string, templateDir string) (
 		return nil, fmt.Errorf("creating parser: %w", err)
 	}
 
-	Preprocess(parser.doc, parser)
+	if err := Preprocess(parser.doc, parser); err != nil {
+		return nil, fmt.Errorf("preprocessing spec: %w", err)
+	}
 
 	g := &Generator{
 		parser:     parser,

--- a/tools/openapi-gen/generator.go
+++ b/tools/openapi-gen/generator.go
@@ -158,6 +158,11 @@ func NewGenerator(specPath string, vars map[string]string, templateDir string) (
 
 // FilterByPackage keeps only operations and models whose x-package matches
 // the given package name.
+//
+// Deprecated: x-package is a legacy extension emitted only by our proto-based
+// generation pipeline. Prefer FilterByTag (operations) and FilterByNamespace
+// (models), which work against any OpenAPI document, including specs
+// generated from platform-api's TypeSpec definitions.
 func (g *Generator) FilterByPackage(pkg string) {
 	// Filter operations
 	var filteredOps []PathOperation

--- a/tools/openapi-gen/main.go
+++ b/tools/openapi-gen/main.go
@@ -21,7 +21,7 @@ type cli struct {
 	Output    string            `short:"o" help:"Output directory for generated files." required:""`
 	Var       map[string]string `short:"v" help:"Set a template variable (e.g. --var package=myapi)." mapsep:","`
 	Templates string            `short:"t" help:"Directory or Git ref (host/org/repo@ref#dir=path) with template overrides." required:""`
-	Package   string            `help:"Filter to only include schemas and operations with this x-package value."`
+	Package   string            `help:"Deprecated: use --tag and --namespace instead. Filter to only include schemas and operations with this x-package value."`
 	Tag       []string          `help:"Filter to only include operations carrying one of these tags." sep:"none"`
 	Namespace []string          `help:"Filter to only include schemas in one of these namespaces (e.g. Instances)." sep:"none"`
 	Flatten   string            `name:"namespace-flatten" help:"Rewrite namespaced schema names: 'strip' drops the namespace prefix, 'join' concatenates segments." enum:",strip,join" default:""`

--- a/tools/openapi-gen/main.go
+++ b/tools/openapi-gen/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/alecthomas/kong"
 	"golang.org/x/sync/errgroup"
@@ -21,6 +22,9 @@ type cli struct {
 	Var       map[string]string `short:"v" help:"Set a template variable (e.g. --var package=myapi)." mapsep:","`
 	Templates string            `short:"t" help:"Directory or Git ref (host/org/repo@ref#dir=path) with template overrides." required:""`
 	Package   string            `help:"Filter to only include schemas and operations with this x-package value."`
+	Tag       []string          `help:"Filter to only include operations carrying one of these tags." sep:"none"`
+	Namespace []string          `help:"Filter to only include schemas in one of these namespaces (e.g. Instances)." sep:"none"`
+	Flatten   string            `name:"namespace-flatten" help:"Rewrite namespaced schema names: 'strip' drops the namespace prefix, 'join' concatenates segments." enum:",strip,join" default:""`
 }
 
 func main() {
@@ -45,6 +49,13 @@ func run(cli *cli) error {
 		vars["x-package"] = cli.Package
 	}
 
+	// Expose the current package (lowercased namespace) for templates to
+	// distinguish local vs. foreign type references. Derived purely from
+	// --namespace so no spec extension is required.
+	if len(cli.Namespace) == 1 {
+		vars["current_package"] = strings.ToLower(cli.Namespace[0])
+	}
+
 	templateDir := cli.Templates
 	if g := parseGitRef(templateDir); g != nil && g.dir != "" {
 		resolved, cleanup, err := resolveTemplateDirFromGit(g)
@@ -63,6 +74,18 @@ func run(cli *cli) error {
 	if cli.Package != "" {
 		generator.FilterByPackage(cli.Package)
 	}
+
+	if len(cli.Tag) > 0 {
+		generator.FilterByTag(cli.Tag)
+	}
+
+	if len(cli.Namespace) > 0 {
+		generator.FilterByNamespace(cli.Namespace)
+	}
+
+	// Flatten namespaced schema names last, after filtering has matched on the
+	// original "Namespace.Name" form.
+	generator.Flatten(flattenModeFromString(cli.Flatten))
 
 	if err := os.MkdirAll(cli.Output, 0o755); err != nil {
 		return fmt.Errorf("error creating output directory: %w", err)

--- a/tools/openapi-gen/namespace.go
+++ b/tools/openapi-gen/namespace.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package main
+
+import (
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// flattenMode controls how namespaced schema names (e.g. "Instances.Instance")
+// are rewritten into valid Go identifiers.
+type flattenMode int
+
+const (
+	// flattenNone leaves names untouched.
+	flattenNone flattenMode = iota
+	// flattenStrip drops the namespace prefix: "Instances.Instance" -> "Instance".
+	// Used for single-package output where every type lives together.
+	flattenStrip
+	// flattenJoin concatenates the segments: "Instances.Instance" -> "InstancesInstance".
+	// Used when domain-prefixed names are desired to avoid collisions.
+	flattenJoin
+)
+
+func flattenModeFromString(s string) flattenMode {
+	switch s {
+	case "strip", "true":
+		return flattenStrip
+	case "join":
+		return flattenJoin
+	default:
+		return flattenNone
+	}
+}
+
+// schemaNamespace returns the namespace prefix of a schema name, or "" if the
+// name is not namespaced. e.g. "Instances.Instance" -> "Instances".
+func schemaNamespace(name string) string {
+	prefix, _, found := strings.Cut(name, ".")
+	if !found {
+		return ""
+	}
+	return prefix
+}
+
+// flattenName transforms a possibly-namespaced schema name per mode. Names
+// without a namespace prefix are returned unchanged, making the operation
+// idempotent and safe to apply more than once.
+func flattenName(name string, mode flattenMode) string {
+	if mode == flattenNone || !strings.Contains(name, ".") {
+		return name
+	}
+	switch mode {
+	case flattenStrip:
+		return name[strings.LastIndex(name, ".")+1:]
+	case flattenJoin:
+		return strings.ReplaceAll(name, ".", "")
+	default:
+		return name
+	}
+}
+
+const schemaRefPrefix = "#/components/schemas/"
+
+func flattenRefString(ref string, mode flattenMode) string {
+	if ref == "" || !strings.HasPrefix(ref, schemaRefPrefix) {
+		return ref
+	}
+	return schemaRefPrefix + flattenName(strings.TrimPrefix(ref, schemaRefPrefix), mode)
+}
+
+// flattenNamespaces rewrites every namespaced schema name in the document —
+// component keys, property orders, $ref targets and inline Title type names —
+// according to mode. After this pass, all type names are valid Go identifiers
+// and the rest of the generator can remain namespace-agnostic.
+func flattenNamespaces(doc *openapi3.T, parser *Parser, mode flattenMode) {
+	if mode == flattenNone || doc.Components == nil {
+		return
+	}
+
+	// Rename component schema keys, recording each type's originating package
+	// (its lowercased namespace) so cross-package references can be qualified
+	// after the prefix is stripped from the name.
+	renamed := make(openapi3.Schemas, len(doc.Components.Schemas))
+	for name, ref := range doc.Components.Schemas {
+		flat := flattenName(name, mode)
+		renamed[flat] = ref
+	}
+	doc.Components.Schemas = renamed
+
+	// Rename registered property orders.
+	if parser != nil && parser.propertyOrders != nil {
+		newOrders := make(map[string][]string, len(parser.propertyOrders))
+		for name, order := range parser.propertyOrders {
+			newOrders[flattenName(name, mode)] = order
+		}
+		parser.propertyOrders = newOrders
+	}
+
+	// Rewrite refs and inline Titles throughout the document. A shared seen set
+	// keeps shared/recursive schema pointers from being visited twice.
+	seen := make(map[*openapi3.Schema]bool)
+	for _, ref := range doc.Components.Schemas {
+		flattenSchemaRef(ref, mode, seen)
+	}
+	if doc.Paths != nil {
+		for _, pathItem := range doc.Paths.Map() {
+			for _, op := range pathItem.Operations() {
+				flattenOperation(op, mode, seen)
+			}
+		}
+	}
+}
+
+func flattenSchemaRef(ref *openapi3.SchemaRef, mode flattenMode, seen map[*openapi3.Schema]bool) {
+	if ref == nil {
+		return
+	}
+	ref.Ref = flattenRefString(ref.Ref, mode)
+
+	s := ref.Value
+	if s == nil || seen[s] {
+		return
+	}
+	seen[s] = true
+
+	// Title doubles as the Go type name for inline enums/objects.
+	if s.Title != "" {
+		s.Title = flattenName(s.Title, mode)
+	}
+
+	for _, p := range s.Properties {
+		flattenSchemaRef(p, mode, seen)
+	}
+	for _, a := range s.AllOf {
+		flattenSchemaRef(a, mode, seen)
+	}
+	for _, a := range s.OneOf {
+		flattenSchemaRef(a, mode, seen)
+	}
+	for _, a := range s.AnyOf {
+		flattenSchemaRef(a, mode, seen)
+	}
+	if s.Not != nil {
+		flattenSchemaRef(s.Not, mode, seen)
+	}
+	if s.Items != nil {
+		flattenSchemaRef(s.Items, mode, seen)
+	}
+	if s.AdditionalProperties.Schema != nil {
+		flattenSchemaRef(s.AdditionalProperties.Schema, mode, seen)
+	}
+}
+
+func flattenOperation(op *openapi3.Operation, mode flattenMode, seen map[*openapi3.Schema]bool) {
+	if op == nil {
+		return
+	}
+	for _, pref := range op.Parameters {
+		if pref.Value != nil && pref.Value.Schema != nil {
+			flattenSchemaRef(pref.Value.Schema, mode, seen)
+		}
+	}
+	if op.RequestBody != nil && op.RequestBody.Value != nil {
+		for _, c := range op.RequestBody.Value.Content {
+			if c.Schema != nil {
+				flattenSchemaRef(c.Schema, mode, seen)
+			}
+		}
+	}
+	if op.Responses != nil {
+		for _, r := range op.Responses.Map() {
+			if r == nil || r.Value == nil {
+				continue
+			}
+			for _, c := range r.Value.Content {
+				if c.Schema != nil {
+					flattenSchemaRef(c.Schema, mode, seen)
+				}
+			}
+		}
+	}
+}

--- a/tools/openapi-gen/namespace.go
+++ b/tools/openapi-gen/namespace.go
@@ -82,9 +82,12 @@ func flattenNamespaces(doc *openapi3.T, parser *Parser, mode flattenMode) {
 		return
 	}
 
-	// Rename component schema keys, recording each type's originating package
-	// (its lowercased namespace) so cross-package references can be qualified
-	// after the prefix is stripped from the name.
+	// Rename component schema keys, flattening namespaced names (e.g.
+	// "Instances.Instance" -> "Instance" or "InstancesInstance" per mode) into
+	// valid Go identifiers. This function only renames; it records no
+	// namespace/package info. Cross-package qualification, where needed, is
+	// handled separately via the "x-package" extension and the
+	// "current_package" template var (see getTypePackage).
 	renamed := make(openapi3.Schemas, len(doc.Components.Schemas))
 	for name, ref := range doc.Components.Schemas {
 		flat := flattenName(name, mode)

--- a/tools/openapi-gen/parser.go
+++ b/tools/openapi-gen/parser.go
@@ -30,6 +30,7 @@ type Model struct {
 	SchemaName string
 	Schema     *openapi3.Schema
 	Package    string // from x-package extension
+	Namespace  string // derived from the "Namespace.Name" schema name prefix
 }
 
 // isURL reports whether s looks like an HTTP(S) URL.
@@ -132,6 +133,7 @@ func (p *Parser) ParseModels() []Model {
 			SchemaName: name,
 			Schema:     schema,
 			Package:    pkg,
+			Namespace:  schemaNamespace(name),
 		})
 	}
 

--- a/tools/openapi-gen/parser.go
+++ b/tools/openapi-gen/parser.go
@@ -29,8 +29,14 @@ type Parser struct {
 type Model struct {
 	SchemaName string
 	Schema     *openapi3.Schema
-	Package    string // from x-package extension
-	Namespace  string // derived from the "Namespace.Name" schema name prefix
+	// Package is derived from the x-package extension.
+	//
+	// Deprecated: x-package is only emitted by our proto-based generation
+	// pipeline. Prefer Namespace, which works for any OpenAPI document.
+	Package string
+	// Namespace is derived from the "Namespace.Name" schema name prefix
+	// (e.g. as emitted by platform-api's TypeSpec compiler).
+	Namespace string
 }
 
 // isURL reports whether s looks like an HTTP(S) URL.

--- a/tools/openapi-gen/preprocessor.go
+++ b/tools/openapi-gen/preprocessor.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/ettle/strcase"
@@ -39,7 +40,7 @@ type preprocessor struct {
 
 // Preprocess hoists all inline schemas in doc into named components/schemas
 // entries, in place.
-func Preprocess(doc *openapi3.T, parser *Parser) {
+func Preprocess(doc *openapi3.T, parser *Parser) error {
 	p := &preprocessor{
 		doc:       doc,
 		parser:    parser,
@@ -61,7 +62,7 @@ func Preprocess(doc *openapi3.T, parser *Parser) {
 		}
 	}
 
-	p.hoistOperationBodies()
+	return p.hoistOperationBodies()
 }
 
 // hoistSchema promotes every anonymous object/enum reachable from schema's
@@ -95,8 +96,10 @@ func (p *preprocessor) hoistValue(slot *openapi3.SchemaRef, name string) {
 
 	switch {
 	case isNameable(value):
-		// An inline object or enum: hoist it directly.
-		*slot = *p.promote(name, value)
+		// An inline object or enum: hoist it directly. The slot's own
+		// description (e.g. a property-specific blurb) would otherwise be
+		// lost once it becomes a bare $ref, so carry it over.
+		*slot = *refWithDescription(p.promote(name, value), value.Description)
 
 	case isInlineArrayItem(value):
 		// An array of inline objects/enums: hoist the item schema, leaving the
@@ -120,18 +123,37 @@ func (p *preprocessor) promote(name string, inline *openapi3.Schema) *openapi3.S
 	return &openapi3.SchemaRef{Ref: refPath(name)}
 }
 
+// refWithDescription attaches description to ref, if non-empty. OpenAPI 3.0
+// doesn't allow sibling keys next to $ref, so a non-empty description is
+// attached using the conventional allOf-wrapped form instead: {allOf:
+// [{$ref: ...}], description: ...}. getProperty (funcs.go) already treats
+// this shape the same as a bare $ref for type resolution, so callers
+// (templates) don't need to special-case it.
+func refWithDescription(ref *openapi3.SchemaRef, description string) *openapi3.SchemaRef {
+	if description == "" || ref.Ref == "" {
+		return ref
+	}
+	return &openapi3.SchemaRef{Value: &openapi3.Schema{
+		AllOf:       []*openapi3.SchemaRef{{Ref: ref.Ref}},
+		Description: description,
+	}}
+}
+
 // hoistOperationBodies hoists inline request and response body schemas, naming
 // them after the operation (e.g. "GetUsersResponse").
-func (p *preprocessor) hoistOperationBodies() {
+func (p *preprocessor) hoistOperationBodies() error {
 	for _, item := range p.doc.Paths.Map() {
 		for _, op := range operations(item) {
 			if op == nil || op.OperationID == "" {
 				continue
 			}
 			p.hoistRequestBody(op)
-			p.hoistResponseBody(op)
+			if err := p.hoistResponseBody(op); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 func (p *preprocessor) hoistRequestBody(op *openapi3.Operation) {
@@ -157,13 +179,29 @@ func (p *preprocessor) hoistRequestBody(op *openapi3.Operation) {
 	}
 }
 
-func (p *preprocessor) hoistResponseBody(op *openapi3.Operation) {
+func (p *preprocessor) hoistResponseBody(op *openapi3.Operation) error {
 	if op.Responses == nil {
-		return
+		return nil
 	}
-	if op.Responses.Len() > 1 {
-		panic("operation " + op.OperationID + " has multiple response bodies; cannot derive a unique schema name")
+
+	// A unique name is only unresolvable when two or more responses carry an
+	// inline JSON body that would all hoist to the same OperationID+"Response"
+	// name. Responses that are $refs, have no JSON body, or hold a body that
+	// hoistBody wouldn't rename anyway (e.g. a bare scalar) don't conflict, so
+	// don't count them.
+	var inline int
+	for _, resp := range op.Responses.Map() {
+		if resp == nil || resp.Value == nil {
+			continue
+		}
+		if json := resp.Value.Content.Get("application/json"); json != nil && isHoistableBody(json.Schema) {
+			inline++
+		}
 	}
+	if inline > 1 {
+		return fmt.Errorf("operation %s has multiple inline response bodies; cannot derive a unique schema name", op.OperationID)
+	}
+
 	for _, resp := range op.Responses.Map() {
 		if resp == nil || resp.Value == nil {
 			continue
@@ -172,13 +210,21 @@ func (p *preprocessor) hoistResponseBody(op *openapi3.Operation) {
 			p.hoistBody(json.Schema, op.OperationID+"Response")
 		}
 	}
+	return nil
 }
 
 // hoistBody hoists an inline body schema, mirroring property hoisting but
 // suffixing array item schemas with "Item" (there is no property name to draw
 // a singular from).
+//
+// Unlike hoistValue, this always leaves a bare $ref rather than wrapping it
+// with the body's own description: templates resolve request/response body
+// types by checking Schema.Ref directly (they don't go through getProperty's
+// allOf-normalisation), so an allOf-wrapped ref here would break type
+// resolution. No template renders a body schema's own description as a
+// comment today, so nothing is lost by not preserving it.
 func (p *preprocessor) hoistBody(slot *openapi3.SchemaRef, name string) {
-	if slot == nil || slot.Ref != "" || slot.Value == nil {
+	if !isHoistableBody(slot) {
 		return
 	}
 	value := slot.Value
@@ -190,6 +236,18 @@ func (p *preprocessor) hoistBody(slot *openapi3.SchemaRef, name string) {
 	case isInlineArrayItem(value):
 		value.Items = p.promote(name+"Item", value.Items.Value)
 	}
+}
+
+// isHoistableBody reports whether slot holds an inline schema that hoistBody
+// would actually promote to a new named component: not already a $ref, and
+// itself an object/enum or an array of them. Anything else (a $ref, a bare
+// scalar, ...) is left untouched by hoistBody, so it can never collide with
+// another hoisted name.
+func isHoistableBody(slot *openapi3.SchemaRef) bool {
+	if slot == nil || slot.Ref != "" || slot.Value == nil {
+		return false
+	}
+	return isNameable(slot.Value) || isInlineArrayItem(slot.Value)
 }
 
 // --- schema classification ---------------------------------------------------

--- a/tools/openapi-gen/preprocessor.go
+++ b/tools/openapi-gen/preprocessor.go
@@ -500,11 +500,15 @@ func (p *preprocessor) processOperationSchemas() {
 				}
 			}
 
-			// Process response bodies
 			if op.Responses != nil {
-				defaultResp := op.Responses.Default()
-				if defaultResp != nil && defaultResp.Value != nil {
-					respContent := defaultResp.Value.Content.Get("application/json")
+				if op.Responses.Len() > 1 {
+					panic("operation " + op.OperationID + " has multiple JSON response bodies; cannot derive a unique schema name")
+				}
+				for _, resp := range op.Responses.Map() {
+					if resp == nil || resp.Value == nil {
+						continue
+					}
+					respContent := resp.Value.Content.Get("application/json")
 					if respContent != nil && respContent.Schema != nil {
 						p.processInlineSchema(respContent.Schema, op.OperationID, "Response")
 					}

--- a/tools/openapi-gen/preprocessor.go
+++ b/tools/openapi-gen/preprocessor.go
@@ -13,602 +13,291 @@ import (
 	"github.com/mitchellh/copystructure"
 )
 
-// preprocessor handles extracting inline schemas from OpenAPI spec
+// The preprocessor rewrites an OpenAPI document so that every schema a code
+// generator might need a Go type for exists as a named entry under
+// components/schemas.
+//
+// OpenAPI lets you define schemas *inline* — directly as a property value, as
+// an array's items, or as a request/response body. A generator, however, needs
+// a name for each type it emits. The preprocessor therefore walks the document,
+// and wherever it finds an anonymous object or enum it "hoists" it: a copy is
+// registered under a synthesized name and the original location is replaced
+// with a $ref to it. The result is a document where types are always reached
+// through a $ref, never defined anonymously in place.
+//
+// This mirrors OpenAPI Generator's InlineModelResolver.
+
 type preprocessor struct {
-	doc            *openapi3.T
-	parser         *Parser
-	processed      map[string]bool // track processed schemas to avoid duplicates
-	createdSchemas map[string]bool // track schemas we created (for cleanup)
+	doc    *openapi3.T
+	parser *Parser
+
+	// processed guards against hoisting the same schema twice (schemas can be
+	// reached both as a top-level component and via recursion into a hoisted
+	// copy). It is keyed by component name.
+	processed map[string]bool
 }
 
-// Preprocess extracts inline schemas from the OpenAPI spec
-// This mimics the behavior of OpenAPI Generator's InlineModelResolver
+// Preprocess hoists all inline schemas in doc into named components/schemas
+// entries, in place.
 func Preprocess(doc *openapi3.T, parser *Parser) {
 	p := &preprocessor{
-		doc:            doc,
-		parser:         parser,
-		processed:      make(map[string]bool),
-		createdSchemas: make(map[string]bool),
+		doc:       doc,
+		parser:    parser,
+		processed: make(map[string]bool),
 	}
 
-	// Collect original schema names first to avoid processing inline schemas we create
-	originalSchemas := make([]string, 0, len(p.doc.Components.Schemas))
-	for name := range p.doc.Components.Schemas {
-		originalSchemas = append(originalSchemas, name)
+	// Snapshot the author-written schema names before adding any of our own,
+	// so the walk never revisits schemas created during this pass (those are
+	// handled inline, as they are created).
+	names := make([]string, 0, len(doc.Components.Schemas))
+	for name := range doc.Components.Schemas {
+		names = append(names, name)
 	}
-	sort.Strings(originalSchemas)
+	sort.Strings(names)
 
-	// Process each original schema
-	for _, name := range originalSchemas {
-		schemaRef := p.doc.Components.Schemas[name]
-		if schemaRef.Value == nil {
+	for _, name := range names {
+		if ref := doc.Components.Schemas[name]; ref != nil {
+			p.hoistSchema(ref.Value, name)
+		}
+	}
+
+	p.hoistOperationBodies()
+}
+
+// hoistSchema promotes every anonymous object/enum reachable from schema's
+// properties to a named component, recursing into each one it creates. name is
+// schema's own component name and seeds the names of anything hoisted out of
+// it (e.g. property "foo" of "Bar" becomes "BarFoo").
+func (p *preprocessor) hoistSchema(schema *openapi3.Schema, name string) {
+	if schema == nil || p.processed[name] {
+		return
+	}
+	p.processed[name] = true
+
+	// Only properties we are free to mutate are considered: a schema's own
+	// properties and those of its *inline* allOf/oneOf/anyOf branches.
+	// Properties reached through a $ref branch belong to another top-level
+	// schema and are hoisted when that schema is processed.
+	for _, prop := range schemaProperties(schema, false) {
+		p.hoistValue(prop.ref, name+strcase.ToPascal(prop.name))
+	}
+}
+
+// hoistValue rewrites a single property/body slot whose value is an anonymous
+// schema into a $ref to a new component named name. Slots that already hold a
+// $ref (including the allOf-wrapped "$ref plus description" form) or a scalar
+// are left untouched.
+func (p *preprocessor) hoistValue(slot *openapi3.SchemaRef, name string) {
+	if slot == nil || slot.Ref != "" || slot.Value == nil {
+		return
+	}
+	value := slot.Value
+
+	switch {
+	case isNameable(value):
+		// An inline object or enum: hoist it directly.
+		*slot = *p.promote(name, value)
+
+	case isInlineArrayItem(value):
+		// An array of inline objects/enums: hoist the item schema, leaving the
+		// array itself in place.
+		value.Items = p.promote(name, value.Items.Value)
+	}
+}
+
+// promote registers a copy of inline as a top-level component named name,
+// records its property order, recurses into it, and returns a $ref to it.
+func (p *preprocessor) promote(name string, inline *openapi3.Schema) *openapi3.SchemaRef {
+	clone := cloneSchema(inline)
+	p.doc.Components.Schemas[name] = &openapi3.SchemaRef{Value: clone}
+
+	if order := schemaPropertyNames(clone); len(order) > 0 {
+		p.parser.SetPropertyOrder(name, order)
+	}
+
+	p.hoistSchema(clone, name)
+
+	return &openapi3.SchemaRef{Ref: refPath(name)}
+}
+
+// hoistOperationBodies hoists inline request and response body schemas, naming
+// them after the operation (e.g. "GetUsersResponse").
+func (p *preprocessor) hoistOperationBodies() {
+	for _, item := range p.doc.Paths.Map() {
+		for _, op := range operations(item) {
+			if op == nil || op.OperationID == "" {
+				continue
+			}
+			p.hoistRequestBody(op)
+			p.hoistResponseBody(op)
+		}
+	}
+}
+
+func (p *preprocessor) hoistRequestBody(op *openapi3.Operation) {
+	if op.RequestBody == nil || op.RequestBody.Value == nil {
+		return
+	}
+	content := op.RequestBody.Value.Content
+
+	if json := content.Get("application/json"); json != nil {
+		p.hoistBody(json.Schema, op.OperationID+"Request")
+	}
+
+	// Binary uploads carry no JSON schema; normalise them to string/binary so
+	// templates can special-case them (e.g. as []byte or io.Reader).
+	if bin := content.Get("application/octet-stream"); bin != nil && bin.Schema != nil && bin.Schema.Value != nil {
+		s := bin.Schema.Value
+		if s.Type == nil || !s.Type.Is("string") {
+			s.Type = &openapi3.Types{"string"}
+		}
+		if s.Format == "" {
+			s.Format = "binary"
+		}
+	}
+}
+
+func (p *preprocessor) hoistResponseBody(op *openapi3.Operation) {
+	if op.Responses == nil {
+		return
+	}
+	if op.Responses.Len() > 1 {
+		panic("operation " + op.OperationID + " has multiple response bodies; cannot derive a unique schema name")
+	}
+	for _, resp := range op.Responses.Map() {
+		if resp == nil || resp.Value == nil {
 			continue
 		}
-		p.gatherInlineModels(schemaRef.Value, name)
+		if json := resp.Value.Content.Get("application/json"); json != nil {
+			p.hoistBody(json.Schema, op.OperationID+"Response")
+		}
 	}
-
-	// Process inline request/response body schemas in operations
-	p.processOperationSchemas()
-
-	// Clean up orphaned schemas
-	p.removeOrphanedSchemas()
 }
 
-// gatherInlineModels recursively extracts inline models from a schema
-// This is based on InlineModelResolver.gatherInlineModels()
-func (p *preprocessor) gatherInlineModels(schema *openapi3.Schema, modelPrefix string) {
-	if schema == nil {
+// hoistBody hoists an inline body schema, mirroring property hoisting but
+// suffixing array item schemas with "Item" (there is no property name to draw
+// a singular from).
+func (p *preprocessor) hoistBody(slot *openapi3.SchemaRef, name string) {
+	if slot == nil || slot.Ref != "" || slot.Value == nil {
 		return
 	}
+	value := slot.Value
 
-	// Prevent processing the same schema twice
-	if p.processed[modelPrefix] {
-		return
-	}
-	p.processed[modelPrefix] = true
+	switch {
+	case isNameable(value):
+		*slot = *p.promote(name, value)
 
-	// Process properties only - this is where inline schemas are created
-	if schema.Type == nil || schema.Type.Is("object") {
-		p.processProperties(schema, modelPrefix)
+	case isInlineArrayItem(value):
+		value.Items = p.promote(name+"Item", value.Items.Value)
 	}
 }
 
-// processProperties processes object properties for inline models
-func (p *preprocessor) processProperties(schema *openapi3.Schema, modelPrefix string) {
-	// Collect properties to process first (to avoid map iteration issues)
-	type propToProcess struct {
-		parentSchema *openapi3.Schema
-		name         string
-		ref          *openapi3.SchemaRef
-	}
-	var propsToProcess []propToProcess
+// --- schema classification ---------------------------------------------------
 
-	// Collect direct properties
-	for propName, propRef := range schema.Properties {
-		propsToProcess = append(propsToProcess, propToProcess{
-			parentSchema: schema,
-			name:         propName,
-			ref:          propRef,
-		})
-	}
-
-	// Also collect properties found in allOf schemas
-	// This handles cases like AttachVolumesRequest where properties are in allOf[0].properties
-	for _, allOfRef := range schema.AllOf {
-		if allOfRef.Value == nil {
-			continue
-		}
-		for propName, propRef := range allOfRef.Value.Properties {
-			propsToProcess = append(propsToProcess, propToProcess{
-				parentSchema: allOfRef.Value,
-				name:         propName,
-				ref:          propRef,
-			})
-		}
-	}
-
-	// Now process all collected properties
-	for _, prop := range propsToProcess {
-		inlineName := p.inlineTypeName(modelPrefix, prop.name)
-		p.setInlineTypeName(prop.ref, inlineName)
-		fromAllOf := prop.parentSchema != schema
-		p.processProperty(prop.parentSchema, prop.name, prop.ref, inlineName, fromAllOf)
-	}
+// isObject reports whether s is an object with properties — something worth a
+// named Go struct. A missing type is treated as "object", matching how
+// OpenAPI specs commonly omit it.
+func isObject(s *openapi3.Schema) bool {
+	return (s.Type == nil || s.Type.Is("object")) && len(s.Properties) > 0
 }
 
-func (p *preprocessor) inlineTypeName(modelPrefix, propName string) string {
-	return modelPrefix + strcase.ToPascal(propName)
+// isEnum reports whether s enumerates a fixed set of values.
+func isEnum(s *openapi3.Schema) bool {
+	return len(s.Enum) > 0
 }
 
-// setInlineTypeName ensures inline schemas have a name for Go types.
-func (p *preprocessor) setInlineTypeName(propRef *openapi3.SchemaRef, inlineName string) {
-	if propRef == nil || propRef.Value == nil {
-		return
-	}
-	propSchema := propRef.Value
-	if len(propSchema.Enum) > 0 {
-		propSchema.Title = inlineName
-	}
-	if propSchema.Type != nil && propSchema.Type.Is("array") && propSchema.Items != nil && propSchema.Items.Value != nil {
-		itemSchema := propSchema.Items.Value
-		if len(itemSchema.Enum) > 0 {
-			itemSchema.Title = inlineName
-		}
-		if itemSchema.Type != nil && itemSchema.Type.Is("object") && len(itemSchema.Properties) > 0 {
-			itemSchema.Title = inlineName
-		}
-	}
-	if propSchema.Type != nil && propSchema.Type.Is("object") && len(propSchema.Properties) > 0 {
-		propSchema.Title = inlineName
-	}
+// isNameable reports whether an anonymous schema deserves to be promoted to a
+// named component (and thus a dedicated Go type).
+func isNameable(s *openapi3.Schema) bool {
+	return s != nil && (isObject(s) || isEnum(s))
 }
 
-// setInlineSchemaTypeNames updates inline enum/object type names for a schema.
-func (p *preprocessor) setInlineSchemaTypeNames(schema *openapi3.Schema, modelPrefix string) {
-	if schema == nil {
-		return
-	}
-	for propName, propRef := range schema.Properties {
-		inlineName := p.inlineTypeName(modelPrefix, propName)
-		p.setInlineTypeName(propRef, inlineName)
-	}
-	for _, allOfRef := range schema.AllOf {
-		if allOfRef.Value == nil {
-			continue
-		}
-		for propName, propRef := range allOfRef.Value.Properties {
-			inlineName := p.inlineTypeName(modelPrefix, propName)
-			p.setInlineTypeName(propRef, inlineName)
-		}
-	}
+// isInlineArrayItem reports whether s is an array whose items are an inline
+// (un-referenced) nameable schema.
+func isInlineArrayItem(s *openapi3.Schema) bool {
+	return s.Type != nil && s.Type.Is("array") &&
+		s.Items != nil && s.Items.Ref == "" && isNameable(s.Items.Value)
 }
 
-func (p *preprocessor) cloneSchema(schema *openapi3.Schema) *openapi3.Schema {
-	if schema == nil {
-		return nil
+// --- property traversal (shared with funcs.go) -------------------------------
+
+// schemaProp is a property together with the schema that declares it.
+type schemaProp struct {
+	name  string
+	ref   *openapi3.SchemaRef
+	owner *openapi3.Schema
+}
+
+// schemaProperties returns every property contributed by schema, flattening
+// allOf/oneOf/anyOf composition. The first occurrence of a name wins and the
+// result is sorted for determinism.
+//
+// followRefs controls whether composition branches that are $refs are
+// descended into. Pass true to see inherited properties (read-only callers);
+// pass false to stay within schemas that are safe to mutate.
+func schemaProperties(schema *openapi3.Schema, followRefs bool) []schemaProp {
+	var props []schemaProp
+	seen := make(map[string]bool)
+
+	var walk func(owner *openapi3.Schema)
+	walk = func(owner *openapi3.Schema) {
+		if owner == nil {
+			return
+		}
+		for name, ref := range owner.Properties {
+			if !seen[name] {
+				seen[name] = true
+				props = append(props, schemaProp{name: name, ref: ref, owner: owner})
+			}
+		}
+		for _, branch := range compositionBranches(owner) {
+			if branch == nil || (branch.Ref != "" && !followRefs) {
+				continue
+			}
+			walk(branch.Value)
+		}
 	}
-	clone, err := copystructure.Copy(schema)
+	walk(schema)
+
+	sort.Slice(props, func(i, j int) bool { return props[i].name < props[j].name })
+	return props
+}
+
+// schemaPropertyNames returns the sorted names of every property contributed by
+// schema, including via composition.
+func schemaPropertyNames(schema *openapi3.Schema) []string {
+	props := schemaProperties(schema, true)
+	names := make([]string, len(props))
+	for i, prop := range props {
+		names[i] = prop.name
+	}
+	return names
+}
+
+// compositionBranches returns the allOf, oneOf and anyOf sub-schemas of s.
+func compositionBranches(s *openapi3.Schema) []*openapi3.SchemaRef {
+	branches := make([]*openapi3.SchemaRef, 0, len(s.AllOf)+len(s.OneOf)+len(s.AnyOf))
+	branches = append(branches, s.AllOf...)
+	branches = append(branches, s.OneOf...)
+	branches = append(branches, s.AnyOf...)
+	return branches
+}
+
+// --- misc helpers ------------------------------------------------------------
+
+// operations returns the operations defined on a path item, in a fixed order.
+func operations(item *openapi3.PathItem) []*openapi3.Operation {
+	return []*openapi3.Operation{item.Get, item.Post, item.Put, item.Delete, item.Patch}
+}
+
+func refPath(name string) string {
+	return "#/components/schemas/" + name
+}
+
+func cloneSchema(s *openapi3.Schema) *openapi3.Schema {
+	clone, err := copystructure.Copy(s)
 	if err != nil {
 		panic(err)
 	}
 	return clone.(*openapi3.Schema)
-}
-
-// processProperty processes a single property for inline model extraction
-func (p *preprocessor) processProperty(parentSchema *openapi3.Schema, propName string, propRef *openapi3.SchemaRef, schemaName string, fromAllOf bool) {
-	if propRef.Value == nil {
-		return
-	}
-
-	prop := propRef.Value
-
-	// ONLY process properties with allOf + single $ref
-	// This is the pattern that needs inline schema extraction
-	if len(prop.AllOf) != 1 || prop.AllOf[0].Ref == "" {
-		return
-	}
-
-	// Get the referenced schema
-	refSchemaName := extractTypeFromRef(prop.AllOf[0].Ref)
-	refSchemaRef := p.doc.Components.Schemas[refSchemaName]
-	if refSchemaRef == nil || refSchemaRef.Value == nil {
-		return
-	}
-	refSchema := refSchemaRef.Value
-
-	// Skip if the referenced schema is a pre-existing top-level component
-	// (not one we created during preprocessing). These should use the direct
-	// reference rather than creating inline copies. The allOf wrapper is only
-	// there to attach a description to the $ref.
-	if !p.createdSchemas[refSchemaName] {
-		parentSchema.Properties[propName] = wrapRefWithDescription(prop.AllOf[0].Ref, prop.Description)
-		return
-	}
-
-	// Skip if the referenced schema has no type and no properties (like GoogleProtobufValue)
-	// These should be mapped to interface{}
-	if refSchema.Type == nil && len(refSchema.Properties) == 0 && len(refSchema.AllOf) == 0 {
-		parentSchema.Properties[propName] = wrapRefWithDescription(prop.AllOf[0].Ref, prop.Description)
-		return
-	}
-
-	// Skip if the referenced schema is just an enum (not an object)
-	// Enums should use the direct reference, not create inline schemas
-	if len(refSchema.Enum) > 0 && len(refSchema.Properties) == 0 {
-		parentSchema.Properties[propName] = wrapRefWithDescription(prop.AllOf[0].Ref, prop.Description)
-		return
-	}
-
-	// Check if the referenced schema is an object with properties
-	if p.isModelNeeded(refSchema) {
-		// IMPORTANT: Only create inline schemas for DIRECT properties, not for properties in allOf
-		// Properties in allOf should use the direct reference with description preserved on the field
-		if fromAllOf {
-			parentSchema.Properties[propName] = wrapRefWithDescription(prop.AllOf[0].Ref, prop.Description)
-			return
-		}
-
-		// Create an inline schema for direct properties
-		// Use the property's description as the type description for the inline schema
-		inlineSchema := p.cloneSchema(refSchema)
-		inlineSchema.Description = prop.Description
-		inlineSchema.Extensions = map[string]any{"x-inline-schema": true}
-
-		p.setInlineSchemaTypeNames(inlineSchema, schemaName)
-
-		// Add to components/schemas
-		p.doc.Components.Schemas[schemaName] = &openapi3.SchemaRef{
-			Value: inlineSchema,
-		}
-
-		// Track that we created this schema
-		p.createdSchemas[schemaName] = true
-
-		// Register property order for the inline schema
-		// Use the order from the referenced schema
-		if refOrder := p.parser.GetPropertyOrder(refSchemaName); len(refOrder) > 0 {
-			p.parser.SetPropertyOrder(schemaName, refOrder)
-		}
-
-		// Replace the property with a ref to the new schema
-		parentSchema.Properties[propName] = &openapi3.SchemaRef{
-			Ref: "#/components/schemas/" + schemaName,
-		}
-
-		// Don't recurse into the referenced schema - it will be processed independently
-		// if it's a top-level schema in components/schemas. This ensures each top-level
-		// schema creates its own inline types (e.g., CreateInstanceRequestScaleToZero and
-		// InstanceScaleToZero are both created from InstanceScaleToZero reference).
-	} else {
-		// For non-objects (enums, simple types), replace with the ref directly
-		parentSchema.Properties[propName] = &openapi3.SchemaRef{
-			Ref: prop.AllOf[0].Ref,
-		}
-	}
-}
-
-// isModelNeeded determines if a schema should be extracted as a separate model
-// Based on InlineModelResolver.isModelNeeded()
-func (p *preprocessor) isModelNeeded(schema *openapi3.Schema) bool {
-	if schema == nil {
-		return false
-	}
-
-	// Pure enums (without properties) should NOT be extracted as inline schemas
-	// They should use the direct reference
-	if len(schema.Enum) > 0 && len(schema.Properties) == 0 {
-		// Check if it also doesn't have allOf/oneOf with properties
-		hasNestedProperties := false
-		for _, allOfRef := range schema.AllOf {
-			if allOfRef.Value != nil && len(allOfRef.Value.Properties) > 0 {
-				hasNestedProperties = true
-				break
-			}
-		}
-		if !hasNestedProperties {
-			return false
-		}
-	}
-
-	// Objects with properties should be extracted
-	if (schema.Type == nil || schema.Type.Is("object")) && len(schema.Properties) > 0 {
-		return true
-	}
-
-	// Check if there are properties in allOf/oneOf
-	for _, allOfRef := range schema.AllOf {
-		if allOfRef.Value == nil {
-			continue
-		}
-		if len(allOfRef.Value.Properties) > 0 {
-			return true
-		}
-		// Check oneOf within allOf
-		for _, oneOfRef := range allOfRef.Value.OneOf {
-			if oneOfRef.Value != nil && len(oneOfRef.Value.Properties) > 0 {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-// removeOrphanedSchemas removes schemas that were created during preprocessing
-// but are never referenced
-func (p *preprocessor) removeOrphanedSchemas() {
-	// Collect all schema references
-	referenced := make(map[string]bool)
-
-	// Scan all schemas to find references
-	for _, schemaRef := range p.doc.Components.Schemas {
-		if schemaRef.Value != nil {
-			p.collectReferences(schemaRef.Value, referenced)
-		}
-	}
-
-	// Also scan operation request/response bodies for references
-	for _, pathItem := range p.doc.Paths.Map() {
-		ops := []*openapi3.Operation{
-			pathItem.Get,
-			pathItem.Post,
-			pathItem.Put,
-			pathItem.Delete,
-			pathItem.Patch,
-		}
-
-		for _, op := range ops {
-			if op == nil {
-				continue
-			}
-
-			// Check request body
-			if op.RequestBody != nil && op.RequestBody.Value != nil {
-				for _, content := range op.RequestBody.Value.Content {
-					if content.Schema != nil {
-						if content.Schema.Ref != "" {
-							refName := extractTypeFromRef(content.Schema.Ref)
-							referenced[refName] = true
-						}
-						if content.Schema.Value != nil {
-							p.collectReferences(content.Schema.Value, referenced)
-						}
-					}
-				}
-			}
-
-			// Check responses
-			if op.Responses != nil {
-				for _, respRef := range op.Responses.Map() {
-					if respRef == nil || respRef.Value == nil {
-						continue
-					}
-					for _, content := range respRef.Value.Content {
-						if content.Schema != nil {
-							if content.Schema.Ref != "" {
-								refName := extractTypeFromRef(content.Schema.Ref)
-								referenced[refName] = true
-							}
-							if content.Schema.Value != nil {
-								p.collectReferences(content.Schema.Value, referenced)
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
-	// Remove created schemas that are not referenced
-	for schemaName := range p.createdSchemas {
-		if referenced[schemaName] {
-			continue
-		}
-		delete(p.doc.Components.Schemas, schemaName)
-		delete(p.parser.propertyOrders, schemaName)
-	}
-}
-
-// collectReferences recursively collects all schema references from a schema
-func (p *preprocessor) collectReferences(schema *openapi3.Schema, referenced map[string]bool) {
-	if schema == nil {
-		return
-	}
-
-	// Check properties
-	for _, propRef := range schema.Properties {
-		if propRef.Ref != "" {
-			refName := extractTypeFromRef(propRef.Ref)
-			referenced[refName] = true
-		}
-		if propRef.Value != nil {
-			p.collectReferences(propRef.Value, referenced)
-		}
-	}
-
-	// Check allOf
-	for _, allOfRef := range schema.AllOf {
-		if allOfRef.Ref != "" {
-			refName := extractTypeFromRef(allOfRef.Ref)
-			referenced[refName] = true
-		}
-		if allOfRef.Value != nil {
-			p.collectReferences(allOfRef.Value, referenced)
-		}
-	}
-
-	// Check oneOf
-	for _, oneOfRef := range schema.OneOf {
-		if oneOfRef.Ref != "" {
-			refName := extractTypeFromRef(oneOfRef.Ref)
-			referenced[refName] = true
-		}
-		if oneOfRef.Value != nil {
-			p.collectReferences(oneOfRef.Value, referenced)
-		}
-	}
-
-	// Check anyOf
-	for _, anyOfRef := range schema.AnyOf {
-		if anyOfRef.Ref != "" {
-			refName := extractTypeFromRef(anyOfRef.Ref)
-			referenced[refName] = true
-		}
-		if anyOfRef.Value != nil {
-			p.collectReferences(anyOfRef.Value, referenced)
-		}
-	}
-
-	// Check items (for arrays)
-	if schema.Items != nil {
-		if schema.Items.Ref != "" {
-			refName := extractTypeFromRef(schema.Items.Ref)
-			referenced[refName] = true
-		}
-		if schema.Items.Value != nil {
-			p.collectReferences(schema.Items.Value, referenced)
-		}
-	}
-
-	// Check additionalProperties
-	if schema.AdditionalProperties.Schema != nil {
-		if schema.AdditionalProperties.Schema.Ref != "" {
-			refName := extractTypeFromRef(schema.AdditionalProperties.Schema.Ref)
-			referenced[refName] = true
-		}
-		if schema.AdditionalProperties.Schema.Value != nil {
-			p.collectReferences(schema.AdditionalProperties.Schema.Value, referenced)
-		}
-	}
-}
-
-// processOperationSchemas extracts inline schemas from request/response bodies
-func (p *preprocessor) processOperationSchemas() {
-	for _, pathItem := range p.doc.Paths.Map() {
-		ops := []*openapi3.Operation{
-			pathItem.Get,
-			pathItem.Post,
-			pathItem.Put,
-			pathItem.Delete,
-			pathItem.Patch,
-		}
-
-		for _, op := range ops {
-			if op == nil || op.OperationID == "" {
-				continue
-			}
-
-			// Process request body
-			if op.RequestBody != nil && op.RequestBody.Value != nil {
-				content := op.RequestBody.Value.Content.Get("application/json")
-				if content != nil && content.Schema != nil {
-					p.processInlineSchema(content.Schema, op.OperationID, "Request")
-				}
-
-				// Handle binary uploads - create a simple schema with type: string, format: binary
-				// This will be mapped to []byte or io.Reader in the Go code
-				binaryContent := op.RequestBody.Value.Content.Get("application/octet-stream")
-				if binaryContent != nil && binaryContent.Schema != nil && binaryContent.Schema.Value != nil {
-					// Don't create a separate schema for binary - just ensure it has a proper type
-					// The template will handle binary specially
-					if binaryContent.Schema.Value.Type == nil || !binaryContent.Schema.Value.Type.Is("string") {
-						binaryContent.Schema.Value.Type = &openapi3.Types{"string"}
-					}
-					if binaryContent.Schema.Value.Format == "" {
-						binaryContent.Schema.Value.Format = "binary"
-					}
-				}
-			}
-
-			if op.Responses != nil {
-				if op.Responses.Len() > 1 {
-					panic("operation " + op.OperationID + " has multiple JSON response bodies; cannot derive a unique schema name")
-				}
-				for _, resp := range op.Responses.Map() {
-					if resp == nil || resp.Value == nil {
-						continue
-					}
-					respContent := resp.Value.Content.Get("application/json")
-					if respContent != nil && respContent.Schema != nil {
-						p.processInlineSchema(respContent.Schema, op.OperationID, "Response")
-					}
-				}
-			}
-		}
-	}
-}
-
-// processInlineSchema converts an inline schema to a ref by creating a new schema
-func (p *preprocessor) processInlineSchema(schemaRef *openapi3.SchemaRef, opID, suffix string) {
-	if schemaRef == nil || schemaRef.Value == nil {
-		return
-	}
-
-	// Skip if it's already a ref
-	if schemaRef.Ref != "" {
-		return
-	}
-
-	schema := schemaRef.Value
-
-	// Only process inline object schemas with properties or arrays of objects
-	if schema.Type == nil {
-		return
-	}
-
-	if schema.Type.Is("object") && len(schema.Properties) > 0 {
-		// Create a new schema name based on the operation ID
-		schemaName := opID + suffix
-
-		// Clone the schema
-		inlineSchema := p.cloneSchema(schema)
-		p.setInlineSchemaTypeNames(inlineSchema, schemaName)
-
-		// Add to components/schemas
-		p.doc.Components.Schemas[schemaName] = &openapi3.SchemaRef{
-			Value: inlineSchema,
-		}
-
-		// Track that we created this schema
-		p.createdSchemas[schemaName] = true
-
-		// Extract property order from the inline schema
-		propOrder := make([]string, 0, len(schema.Properties))
-		for propName := range schema.Properties {
-			propOrder = append(propOrder, propName)
-		}
-		sort.Strings(propOrder)
-		if len(propOrder) > 0 {
-			p.parser.SetPropertyOrder(schemaName, propOrder)
-		}
-
-		// Replace with a ref
-		schemaRef.Ref = "#/components/schemas/" + schemaName
-		schemaRef.Value = nil
-	} else if schema.Type.Is("array") && schema.Items != nil && schema.Items.Ref == "" && schema.Items.Value != nil {
-		// Handle inline array item schemas
-		itemSchema := schema.Items.Value
-		if itemSchema.Type != nil && itemSchema.Type.Is("object") && len(itemSchema.Properties) > 0 {
-			// Create a new schema name for the array items
-			schemaName := opID + suffix + "Item"
-
-			// Clone the item schema
-			inlineSchema := p.cloneSchema(itemSchema)
-			p.setInlineSchemaTypeNames(inlineSchema, schemaName)
-
-			// Add to components/schemas
-			p.doc.Components.Schemas[schemaName] = &openapi3.SchemaRef{
-				Value: inlineSchema,
-			}
-
-			// Track that we created this schema
-			p.createdSchemas[schemaName] = true
-
-			// Extract property order
-			propOrder := make([]string, 0, len(itemSchema.Properties))
-			for propName := range itemSchema.Properties {
-				propOrder = append(propOrder, propName)
-			}
-			sort.Strings(propOrder)
-			if len(propOrder) > 0 {
-				p.parser.SetPropertyOrder(schemaName, propOrder)
-			}
-
-			// Replace items with a ref
-			schema.Items.Ref = "#/components/schemas/" + schemaName
-			schema.Items.Value = nil
-		}
-	}
-}
-
-// wrapRefWithDescription creates a schema that wraps a $ref while preserving description
-func wrapRefWithDescription(ref string, description string) *openapi3.SchemaRef {
-	return &openapi3.SchemaRef{
-		Value: &openapi3.Schema{
-			AllOf: []*openapi3.SchemaRef{
-				{Ref: ref},
-			},
-			Description: description,
-		},
-	}
 }

--- a/tools/openapi-gen/templates/go-server/model_simple.go.tmpl
+++ b/tools/openapi-gen/templates/go-server/model_simple.go.tmpl
@@ -6,47 +6,6 @@
 {{- if $schema.Description}}
 // {{$schema.Description | replace "\n" "\n// "}}
 {{- end}}
-{{- /* Inline enum types for fields */ -}}
-{{- range $propName := $propNames -}}
-{{- $prop := getProperty $schema $propName}}
-{{- $enumSchema := ""}}
-{{- $enumDescription := ""}}
-{{- if and $prop $prop.Enum}}
-{{- $enumSchema = $prop}}
-{{- $enumDescription = $prop.Description}}
-{{- else if and $prop (eq (getType $prop) "array") $prop.Items $prop.Items.Value $prop.Items.Value.Enum}}
-{{- $enumSchema = $prop.Items.Value}}
-{{- $enumDescription = $prop.Description}}
-{{- end}}
-{{- if $enumSchema}}
-{{- $enumTypeName := schemaToGoType $enumSchema }}
-{{- if $enumDescription -}}
-// {{$enumDescription | replace "\n" "\n// "}}
-{{end -}}
-type {{$enumTypeName}} string
-
-const (
-{{- range $enumSchema.Enum}}
-	{{$enumTypeName}}{{pascalcase (printf "%v" .)}} {{$enumTypeName}} = {{printf "%q" .}}
-{{- end}}
-)
-
-// Values returns all possible values of the {{$enumTypeName}} enum.
-func ({{$enumTypeName}}) Values() []{{$enumTypeName}} {
-	return []{{$enumTypeName}}{
-{{- range $enumSchema.Enum}}
-		{{$enumTypeName}}{{pascalcase (printf "%v" .)}},
-{{- end}}
-	}
-}
-
-// String returns the {{$enumTypeName}} as a string.
-func (e {{$enumTypeName}}) String() string {
-	return string(e)
-}
-{{ end }}
-
-{{- end}}
 type {{$schemaName}} struct {
 {{- range $propName := propertyNamesOrdered $schemaName $schema}}
 {{- $prop := getProperty $schema $propName}}


### PR DESCRIPTION
See commits for details.

But generally, this expands the amount of OpenAPI schemas that this tool can understand and generate for.

The intention is that this will be used as we migrate away from using proto-based OpenAPI generation and towards typespec-based based OpenAPI generation. However, old callers of this package *should* keep working at intended.